### PR TITLE
Add golangci-linter with default config derived by ubers go styleguide

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,22 @@
+name: golangci-lint
+on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    branches: [ 'main' ]
+permissions:
+  contents: read
+jobs:
+  golangci-lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.19.x'
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+# Refer to golangci-lint's example config file for more options and information:
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+
+run:
+  timeout: 2m
+  modules-download-mode: readonly
+
+linters:
+  enable:
+    - errcheck
+    - goimports
+    - golint
+    - govet
+    - staticcheck
+
+issues:
+  exclude-use-default: false
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cmd/authz/apiserver_test.go
+++ b/cmd/authz/apiserver_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/authzed/authzed-go/proto/authzed/api/v1"
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 )
 
 func TestHelloworldService(t *testing.T) {

--- a/cmd/authz/main.go
+++ b/cmd/authz/main.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net/http"
+
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"net/http"
 )
 
 func main() {

--- a/cmd/authz/main.go
+++ b/cmd/authz/main.go
@@ -4,16 +4,15 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"net/http"
-
-	"github.com/authzed/authzed-go/proto/authzed/api/v1"
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"net/http"
 )
 
 func main() {
 	// This is needed to make `glog` believe that the flags have already been parsed, otherwise
-	// every log messages is prefixed by an error message stating the the flags haven't been
+	// every log messages is prefixed by an error message stating the flags haven't been
 	// parsed.
 	_ = flag.CommandLine.Parse([]string{})
 
@@ -37,14 +36,18 @@ func main() {
 	//TODO Remove later - Helloworld
 	http.HandleFunc("/", HelloServer)
 	http.HandleFunc("/CheckPermission", CheckPermission)
-	http.ListenAndServe(":8080", nil)
+	_ = http.ListenAndServe(":8080", nil)
 }
 
-// TODO - Remove later
+// HelloServer TODO - Remove later
 func HelloServer(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
+	_, err := fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
+	if err != nil {
+		return
+	}
 }
 
+// CheckPermission Dummy endpoint, will change
 func CheckPermission(w http.ResponseWriter, r *http.Request) {
 	var cpr v1.CheckPermissionRequest
 


### PR DESCRIPTION
This PR adds https://github.com/golangci/golangci-lint linting to the pipeline as a concurrent job as per their [GHa usage recommendation](https://github.com/golangci/golangci-lint-action#how-to-use).

It also adds a linting config based on the uber [go style guide](https://github.com/uber-go/guide/blob/master/style.md#linting) - only difference: I set the timeout for now to 2minutes, derived from playbook-dispatchers [use of this GHa](https://github.com/RedHatInsights/playbook-dispatcher/blob/master/.github/workflows/golangci-lint.yml)

The config file should be read as it is in the root of the repo, see [docs](https://golangci-lint.run/usage/configuration/#config-file)