### PR TITLE
Add linux/arm64 platform image to build.

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: | 
             quay.io/ciam_authz/authz:latest,


### PR DESCRIPTION
If we want to add linux/arm64 platform image to the build.