### PR TITLE
Updated gRPC service and swagger docs for correct HTTP response codes

### DIFF
--- a/api/buf.gen.yaml
+++ b/api/buf.gen.yaml
@@ -22,6 +22,7 @@ plugins:
     out: gen
     opt:
       - grpc_api_configuration=v1/gw_mapping.yaml
+      - openapi_configuration=v1/gw_openapi_mapping.yaml
       - output_format=yaml
     # # protoc-gen-openapiv2 needs to be installed, generate swagger config files based on proto files
   - name: openapiv2

--- a/api/gen/v1/core.swagger.yaml
+++ b/api/gen/v1/core.swagger.yaml
@@ -1,9 +1,25 @@
 swagger: "2.0"
 info:
-  title: v1/core.proto
-  version: version not set
+  title: CIAM Authz
+  description: This is the CIAM-AuthZ service based on the OpenAPI 2.0 specification.
+  version: 1.0.11
+  contact:
+    email: ciam-authz@redhat.com
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: CheckPermission
+  - name: AuthZ
+    description: Everything about your AuthZ
+    externalDocs:
+      description: CIAM AuthZ
+      url: http://<TODO>
+  - name: user
+    description: Operations about user
+schemes:
+  - http
+  - https
 consumes:
   - application/json
 produces:
@@ -11,12 +27,27 @@ produces:
 paths:
   /v1/permissions/check:
     post:
+      summary: Checks the permission and returs allowed (true) or not allowed (false)
+      description: CheckPermission end point is used by the clients to determine if the given "subject" has the given permission "Operation" on a given "Resource"
       operationId: CheckPermission_CheckPermission
       responses:
         "200":
           description: A successful response.
           schema:
             $ref: '#/definitions/v1CheckPermissionResponse'
+          examples:
+            application/json:
+              description: ""
+              result: true
+        "401":
+          description: Returned when no valid identity information provided to a protected endpoint.
+          schema: {}
+        "403":
+          description: Returned when the user does not have permission to access the resource.
+          schema: {}
+        "500":
+          description: Returned when an unexpected error occurs during request processing.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:

--- a/api/v1/gw_openapi_mapping.yaml
+++ b/api/v1/gw_openapi_mapping.yaml
@@ -1,0 +1,47 @@
+openapiOptions:
+  file:
+    - file: v1/core.proto
+      option:
+        info:
+          title: CIAM Authz
+          description: This is the CIAM-AuthZ service based on the OpenAPI 2.0 specification.
+          contact:
+            email: ciam-authz@redhat.com
+          license:
+            name: Apache 2.0
+            url: http://www.apache.org/licenses/LICENSE-2.0.html
+          version: 1.0.11
+        tags:
+            - name: AuthZ
+              description: Everything about your AuthZ
+              externalDocs:
+                description: CIAM AuthZ 
+                url: http://<TODO>
+            - name: user
+              description: Operations about user  
+        schemes:
+          - HTTP
+          - HTTPS
+        consumes:
+          - application/json
+        produces:
+          - application/json
+        responses:
+          "401":
+            description: Returned when no valid identity information provided to a protected endpoint.
+            schema: {}
+          "403":
+            description: Returned when the user does not have permission to access the resource.
+            schema: {}
+          "500":
+            description: Returned when an unexpected error occurs during request processing.
+            schema: {}
+  method:
+    - method: api.v1.CheckPermission.CheckPermission
+      option:
+        summary: Checks the permission and returs allowed (true) or not allowed (false)
+        description: CheckPermission end point is used by the clients to determine if the given "subject" has the given permission "Operation" on a given "Resource"
+        responses:
+          "200":
+            examples:
+              "application/json": '{"result": true, "description": ""}'

--- a/app/Errors.go
+++ b/app/Errors.go
@@ -1,0 +1,9 @@
+package app
+
+import "errors"
+
+// ErrNotAuthorized is returned when the identity invoking the API does not have permission to invoke that operation.
+var ErrNotAuthorized = errors.New("NotAuthorized")
+
+// ErrNotAuthenticated is returned when anonymously invoking an endpoint that requires an identity
+var ErrNotAuthenticated = errors.New("NotAuthenticated")

--- a/app/Principal.go
+++ b/app/Principal.go
@@ -6,6 +6,7 @@ type Principal struct {
 	ID string
 }
 
+// HasIdentity returns true if this principal represents an identity or false if this principal is anonymous.
 func (p *Principal) HasIdentity() bool {
 	return p.ID != ""
 }

--- a/app/Principal.go
+++ b/app/Principal.go
@@ -5,3 +5,7 @@ type Principal struct {
 	//IDs are permanent and unique identifying values.
 	ID string
 }
+
+func (p *Principal) HasIdentity() bool {
+	return p.ID != ""
+}

--- a/app/Principal.go
+++ b/app/Principal.go
@@ -6,7 +6,17 @@ type Principal struct {
 	ID string
 }
 
-// HasIdentity returns true if this principal represents an identity or false if this principal is anonymous.
-func (p *Principal) HasIdentity() bool {
-	return p.ID != ""
+// IsAnonymous returns true if this Principal has no identity information and returns false if this Principal represents a specific identity
+func (p Principal) IsAnonymous() bool {
+	return p.ID == ""
+}
+
+// NewPrincipal constructs a new principal with the given identifier.
+func NewPrincipal(id string) Principal {
+	return Principal{ID: id}
+}
+
+// NewAnonymousPrincipal constructs a new principal without an identity.
+func NewAnonymousPrincipal() Principal {
+	return Principal{ID: ""}
 }

--- a/app/Principal_test.go
+++ b/app/Principal_test.go
@@ -1,0 +1,19 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrincipalIsAnonymousTrueForAnonymousPrincipal(t *testing.T) {
+	p := NewAnonymousPrincipal()
+
+	assert.True(t, p.IsAnonymous(), "Should have been anonymous.")
+}
+
+func TestPrincipalIsAnonymousFalseForSpecificPrincipal(t *testing.T) {
+	p := NewPrincipal("alice")
+
+	assert.False(t, p.IsAnonymous(), "Should NOT have been anonymous.")
+}

--- a/app/controllers/Access.go
+++ b/app/controllers/Access.go
@@ -18,7 +18,7 @@ func NewAccess(store dependencies.AuthzStore) Access {
 
 // Check processes a CheckRequest and returns true or false if successful, otherwise error
 func (a Access) Check(req contracts.CheckRequest) (bool, error) {
-	if !req.Requestor.HasIdentity() {
+	if req.Requestor.IsAnonymous() {
 		return false, app.ErrNotAuthenticated
 	}
 

--- a/host/GrpcServer.go
+++ b/host/GrpcServer.go
@@ -13,8 +13,10 @@ import (
 
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // GrpcServer represents a GrpcServer host service
@@ -25,29 +27,26 @@ type GrpcServer struct {
 // CheckPermission processes an authorization check and returns whether or not the operation would be allowed
 func (r *GrpcServer) CheckPermission(ctx context.Context, rpcReq *core.CheckPermissionRequest) (*core.CheckPermissionResponse, error) {
 
-	if token, ok := getBearerTokenFromContext(ctx, []string{"grpcgateway-authorization", "bearer-token"}); ok { //'bearer-token' is a guess at the metadata key for a token in a gRPC request
+	token := getBearerTokenFromContext(ctx)
 
-		req := contracts.CheckRequest{
-			Request: contracts.Request{
-				Requestor: app.Principal{ID: token},
-			},
-			Subject:   app.Principal{ID: rpcReq.Subject},
-			Operation: rpcReq.Operation,
-			Resource:  app.Resource{Type: rpcReq.Resourcetype, ID: rpcReq.Resourceid},
-		}
-
-		action := controllers.NewAccess(r.services.Store)
-
-		result, err := action.Check(req)
-
-		if err != nil {
-			return nil, err
-		}
-
-		return &core.CheckPermissionResponse{Result: result}, nil
+	req := contracts.CheckRequest{
+		Request: contracts.Request{
+			Requestor: app.Principal{ID: token},
+		},
+		Subject:   app.Principal{ID: rpcReq.Subject},
+		Operation: rpcReq.Operation,
+		Resource:  app.Resource{Type: rpcReq.Resourcetype, ID: rpcReq.Resourceid},
 	}
 
-	return nil, errors.New("Missing identity") //401?
+	action := controllers.NewAccess(r.services.Store)
+
+	result, err := action.Check(req)
+
+	if err != nil {
+		return nil, convertDomainErrorToGrpc(err)
+	}
+
+	return &core.CheckPermissionResponse{Result: result}, nil
 }
 
 // NewGrpcServer instantiates a new GRpc host service
@@ -90,15 +89,26 @@ func (r *GrpcServer) Host(wait *sync.WaitGroup) {
 	}
 }
 
-func getBearerTokenFromContext(ctx context.Context, names []string) (string, bool) {
-	for _, name := range names {
+func convertDomainErrorToGrpc(err error) error {
+	switch {
+	case errors.Is(err, app.ErrNotAuthenticated):
+		return status.Error(codes.Unauthenticated, "Anonymous access is not allowed.")
+	case errors.Is(err, app.ErrNotAuthorized):
+		return status.Error(codes.PermissionDenied, "Access denied.")
+	default:
+		return status.Error(codes.Unknown, "Internal server error.")
+	}
+}
+
+func getBearerTokenFromContext(ctx context.Context) string {
+	for _, name := range []string{"grpcgateway-authorization", "bearer-token"} {
 		if metadata, ok := metadata.FromIncomingContext(ctx); ok {
 			headers := metadata.Get(name)
 			if len(headers) > 0 {
-				return headers[0], true
+				return headers[0]
 			}
 		}
 	}
 
-	return "", false
+	return ""
 }

--- a/host/Web_test.go
+++ b/host/Web_test.go
@@ -18,7 +18,7 @@ func TestCheckErrorsWhenCallerNotAuthorized(t *testing.T) {
 	resp := runRequest(post("/v1/permissions/check", "other system",
 		`{"subject": "good", "operation": "use", "resourcetype": "Feature", "resourceid": "Wisdom"}`))
 
-	assert.Equal(t, 500, resp.StatusCode) //TODO: this should return 403
+	assert.Equal(t, 403, resp.StatusCode)
 }
 
 func TestCheckErrorsWhenTokenMissing(t *testing.T) {
@@ -26,7 +26,7 @@ func TestCheckErrorsWhenTokenMissing(t *testing.T) {
 	resp := runRequest(post("/v1/permissions/check", "",
 		`{"subject": "good", "operation": "use", "resourcetype": "Feature", "resourceid": "Wisdom"}`))
 
-	assert.Equal(t, 500, resp.StatusCode) //TODO: this should return 401
+	assert.Equal(t, 401, resp.StatusCode)
 }
 
 func TestCheckReturnsTrueWhenUserAuthorized(t *testing.T) {


### PR DESCRIPTION
For status codes
- The gRPC service now sets response codes
- The 'controller' object is now in charge of whether an identity is required and checking for it
- There's a new Errors.go with sentinel error values
- The gRPC service will set different status codes depending on the exact error from below
- The gateway automatically translates gRPC response codes to HTTP status codes
- The web tests now assert the correct HTTP status codes

For documentation
- There's now a gw_openapi_mapping.yaml that provides additional data for the OpenAPI output
- I moved most of the hand-written OpenAPI info over to it to be included in future generated docs