### PR TITLE
Added awareness of -short flag to enable fast test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ run `go run cmd/main.go --endpoint=<endpoint> --token=<token> --store=spicedb`
 
 # Testing
 
-run `go test ./...` (use -count=1 to avoid caching)
+For complete tests, run `go test ./...` (use -count=1 to avoid caching)
+For abbreviated tests, run `go test -short ./...`
+
 
 # Building
 

--- a/infrastructure/repository/authzed/SpiceDbAccessRepository_test.go
+++ b/infrastructure/repository/authzed/SpiceDbAccessRepository_test.go
@@ -56,6 +56,10 @@ func spicedbTestClient(_ *testing.T, port string) (*authzed.Client, error) {
 }
 
 func TestSpiceDB(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	port, err := runSpiceDBTestServer(t)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This is a built-in Golang feature that allows a 'short' test run to be requested and sets a flag that tests can see (testing.Short()) and optionally shorten themselves, like by skipping, using a smaller dataset, or testing in a simplified way. This flag defaults to false leaving the full test run the default behavior, and tests can be aware of it on an opt-in basis (ex: tests that run an external container.)