### PR TITLE
Fixes for local development kind k8s setup

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -75,7 +75,7 @@ service/kubernetes      ClusterIP   10.96.0.1      <none>        443/TCP    9m6s
 ```
 ## Step 5: Call the service
 
-Navigate to http://localhost:8080/authz/whoever%20is%20reading%20this or run a curl to the http://localhost:8080/authz endpoint to see the service runs and returns a greeting as expected. 
+Navigate to http://localhost:8080/whoever%20is%20reading%20this or run a curl to the http://localhost:8080/ endpoint to see the service runs and returns a greeting as expected. 
 
 ## Step 6: Remove everything
 


### PR DESCRIPTION
For the local dev setup, if you run `make kind-deploy` right after `make kind-create`, `make kind-deploy` fails when it tried to add the ingress for the authz service. The reason is that the nginx controller is not ready. (This takes almost a minute on my machine for some reason.) The change to the kind-create make target waits for the nginx controller to be in place.

Changes:
- Make target change as described, above.
- Small k8s README change to remove authz from path.