### PR TITLE
Slim use of principalrepository

### DIFF
--- a/api/http/Server_test.go
+++ b/api/http/Server_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestCheckErrorsWhenCallerNotAuthorized(t *testing.T) {
+	t.SkipNow()
 	t.Parallel()
 	resp := runRequest(post("/v1alpha/check", "bad",
 		`{"subject": "good", "operation": "op", "resourcetype": "Feature", "resourceid": "smarts"}`))

--- a/api/http/Server_test.go
+++ b/api/http/Server_test.go
@@ -5,6 +5,7 @@ import (
 	"authz/application"
 	"authz/domain/contracts"
 	"authz/domain/model"
+	vo "authz/domain/valueobjects"
 	"authz/infrastructure/repository/mock"
 	"io"
 	"net/http"
@@ -153,19 +154,19 @@ func assertJSONResponse(t *testing.T, resp *http.Response, statusCode int, templ
 }
 
 func mockAccessRepository() contracts.AccessRepository {
-	return &mock.StubAccessRepository{Data: map[string]bool{
+	return &mock.StubAccessRepository{Data: map[vo.SubjectID]bool{
 		"system": true,
 		"okay":   true,
 		"bad":    false,
-	}, LicensedSeats: map[string]map[string]bool{}}
+	}, LicensedSeats: map[vo.SubjectID]map[string]bool{}}
 }
 
 func mockPrincipalRepository() contracts.PrincipalRepository {
 	return &mock.StubPrincipalRepository{
-		Principals: map[string]model.Principal{
-			"system": model.NewPrincipal("system", "smarts"),
-			"okay":   model.NewPrincipal("okay", "aspian"),
-			"bad":    model.NewPrincipal("bad", "aspian"),
+		Principals: map[vo.SubjectID]model.Principal{
+			"system": model.NewPrincipal("system"),
+			"okay":   model.NewPrincipal("okay"),
+			"bad":    model.NewPrincipal("bad"),
 		},
 	}
 }

--- a/application/AccessAppService.go
+++ b/application/AccessAppService.go
@@ -37,16 +37,12 @@ func NewAccessAppService(accessRepo *contracts.AccessRepository, principalRepo c
 // Check calls the domainservice using a CheckEvent and can be used with every server impl if wanted.
 func (p *AccessAppService) Check(req CheckRequest) (vo.AccessDecision, error) {
 	event := model.CheckEvent{
-		Subject:   model.Principal{ID: req.Subject},
+		SubjectID: vo.SubjectID(req.Subject),
 		Operation: req.Operation,
 		Resource:  model.Resource{Type: req.ResourceType, ID: req.ResourceID},
 	}
 
-	var err error
-	event.Requestor, err = p.principalRepo.GetByID(req.Requestor)
-	if err != nil {
-		return vo.AccessDecision(false), err
-	}
+	event.Requestor = vo.SubjectID(req.Requestor)
 
 	checkResult := services.NewAccessService(*p.accessRepo)
 

--- a/application/LicenseAppService.go
+++ b/application/LicenseAppService.go
@@ -4,6 +4,7 @@ import (
 	"authz/domain/contracts"
 	"authz/domain/model"
 	"authz/domain/services"
+	vo "authz/domain/valueobjects"
 	"context"
 )
 
@@ -41,20 +42,16 @@ func (s *LicenseAppService) ModifySeats(req ModifySeatAssignmentRequest) error {
 		Service: model.Service{ID: req.ServiceID},
 	}
 
-	var err error
-	evt.Requestor, err = s.principalRepo.GetByID(req.Requestor)
-	if err != nil {
-		return err
+	evt.Requestor = vo.SubjectID(req.Requestor)
+
+	evt.Assign = make([]vo.SubjectID, len(req.Assign))
+	for i, id := range req.Assign {
+		evt.Assign[i] = vo.SubjectID(id)
 	}
 
-	evt.Assign, err = s.principalRepo.GetByIDs(req.Assign)
-	if err != nil {
-		return err
-	}
-
-	evt.UnAssign, err = s.principalRepo.GetByIDs(req.Unassign)
-	if err != nil {
-		return err
+	evt.UnAssign = make([]vo.SubjectID, len(req.Unassign))
+	for i, id := range req.Unassign {
+		evt.UnAssign[i] = vo.SubjectID(id)
 	}
 
 	seatService := services.NewSeatLicenseService(s.seatRepo, s.accessRepo)

--- a/bootstrap/AccessRepositoryBuilder.go
+++ b/bootstrap/AccessRepositoryBuilder.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"authz/domain/contracts"
+	vo "authz/domain/valueobjects"
 	"authz/infrastructure/repository/authzed"
 	"authz/infrastructure/repository/fga"
 	"authz/infrastructure/repository/mock"
@@ -27,18 +28,18 @@ func (e *AccessRepositoryBuilder) WithImplementation(implID string) *AccessRepos
 func (e *AccessRepositoryBuilder) Build() (contracts.AccessRepository, error) {
 	switch e.impl {
 	case "stub":
-		return &mock.StubAccessRepository{Data: getMockData(), LicensedSeats: map[string]map[string]bool{}}, nil
+		return &mock.StubAccessRepository{Data: getMockData(), LicensedSeats: map[vo.SubjectID]map[string]bool{}}, nil
 	case "spicedb":
 		return &authzed.SpiceDbAccessRepository{}, nil
 	case "openfga":
 		return &fga.OpenFgaAccessRepository{}, nil
 	default:
-		return &mock.StubAccessRepository{Data: getMockData(), LicensedSeats: map[string]map[string]bool{}}, nil
+		return &mock.StubAccessRepository{Data: getMockData(), LicensedSeats: map[vo.SubjectID]map[string]bool{}}, nil
 	}
 }
 
-func getMockData() map[string]bool {
-	return map[string]bool{
+func getMockData() map[vo.SubjectID]bool {
+	return map[vo.SubjectID]bool{
 		"token": true,
 		"alice": true,
 		"bob":   true,

--- a/bootstrap/PrincipalRepositoryBuilder.go
+++ b/bootstrap/PrincipalRepositoryBuilder.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"authz/domain/contracts"
 	"authz/domain/model"
+	vo "authz/domain/valueobjects"
 	"authz/infrastructure/repository/mock"
 )
 
@@ -32,11 +33,11 @@ func (b *PrincipalRepositoryBuilder) Build() contracts.PrincipalRepository {
 	}
 }
 
-func getMockPrincipalData() map[string]model.Principal {
-	return map[string]model.Principal{
-		"token": model.NewPrincipal("token", "aspian"),
-		"alice": model.NewPrincipal("alice", "aspian"),
-		"bob":   model.NewPrincipal("bob", "aspian"),
-		"chuck": model.NewPrincipal("chuck", "aspian"),
+func getMockPrincipalData() map[vo.SubjectID]model.Principal {
+	return map[vo.SubjectID]model.Principal{
+		"token": model.NewPrincipal("token"),
+		"alice": model.NewPrincipal("alice"),
+		"bob":   model.NewPrincipal("bob"),
+		"chuck": model.NewPrincipal("chuck"),
 	}
 }

--- a/domain/contracts/AccessRepository.go
+++ b/domain/contracts/AccessRepository.go
@@ -9,6 +9,6 @@ import (
 
 // AccessRepository - the contract for the access repository
 type AccessRepository interface {
-	CheckAccess(principal model.Principal, operation string, resource model.Resource) (vo.AccessDecision, error)
+	CheckAccess(subjectID vo.SubjectID, operation string, resource model.Resource) (vo.AccessDecision, error)
 	NewConnection(endpoint string, token string, isBlocking bool) //TODO: Remove from interface.don't think it is needed here.
 }

--- a/domain/contracts/PrincipalRepository.go
+++ b/domain/contracts/PrincipalRepository.go
@@ -1,11 +1,14 @@
 package contracts
 
-import "authz/domain/model"
+import (
+	"authz/domain/model"
+	"authz/domain/valueobjects"
+)
 
 // PrincipalRepository is a contract that describes the required operations for accessing principal data
 type PrincipalRepository interface {
 	// GetByID retrieves a principal for the given ID. If no ID is provided (ex: empty string), it returns an anonymous principal. If any error occurs, it's returned.
-	GetByID(id string) (model.Principal, error)
+	GetByID(id valueobjects.SubjectID) (model.Principal, error)
 	// GetByIDs is a bulk version of GetByID to allow the underlying implementation to optimize access to sets of principals and should otherwise have the same behavior.
-	GetByIDs(ids []string) ([]model.Principal, error)
+	GetByIDs(ids []valueobjects.SubjectID) ([]model.Principal, error)
 }

--- a/domain/contracts/SeatLicenseRepository.go
+++ b/domain/contracts/SeatLicenseRepository.go
@@ -1,13 +1,16 @@
 package contracts
 
-import "authz/domain/model"
+import (
+	"authz/domain/model"
+	vo "authz/domain/valueobjects"
+)
 
 // SeatLicenseRepository is a contract that describes the required operations for accessing and manipulating per-seat license data
 type SeatLicenseRepository interface {
 	// AssignSeat assigns the given principal a seat for the given service
-	AssignSeat(principal model.Principal, orgId string, svc model.Service) error
+	AssignSeat(subjectID vo.SubjectID, orgID string, svc model.Service) error
 	// UnAssignSeat removes the seat assignment for the given principal for the given service
-	UnAssignSeat(principal model.Principal, orgId string, svc model.Service) error
+	UnAssignSeat(subjectID vo.SubjectID, orgID string, svc model.Service) error
 }
 
 // TODO

--- a/domain/contracts/SeatLicenseRepository.go
+++ b/domain/contracts/SeatLicenseRepository.go
@@ -5,9 +5,9 @@ import "authz/domain/model"
 // SeatLicenseRepository is a contract that describes the required operations for accessing and manipulating per-seat license data
 type SeatLicenseRepository interface {
 	// AssignSeat assigns the given principal a seat for the given service
-	AssignSeat(principal model.Principal, svc model.Service) error
+	AssignSeat(principal model.Principal, orgId string, svc model.Service) error
 	// UnAssignSeat removes the seat assignment for the given principal for the given service
-	UnAssignSeat(principal model.Principal, svc model.Service) error
+	UnAssignSeat(principal model.Principal, orgId string, svc model.Service) error
 }
 
 // TODO

--- a/domain/model/CheckEvent.go
+++ b/domain/model/CheckEvent.go
@@ -1,6 +1,8 @@
 // Package model contains the Domain model classes.
 package model
 
+import "authz/domain/valueobjects"
+
 // A CheckEvent contains the parameters to request whether a subject can perform an operation on a resource
 type CheckEvent struct {
 	//The common request parameters
@@ -8,7 +10,7 @@ type CheckEvent struct {
 	//The operation that would be performed
 	Operation string
 	//The candidate subject who would perform the operation
-	Subject Principal
+	SubjectID valueobjects.SubjectID
 	//The resource on which the operation would be performed
 	Resource Resource
 }

--- a/domain/model/ModifySeatAssignmentEvent.go
+++ b/domain/model/ModifySeatAssignmentEvent.go
@@ -1,10 +1,12 @@
 package model
 
+import vo "authz/domain/valueobjects"
+
 // ModifySeatAssignmentEvent represents a request to change per-seat license assignments for a given organization and service
 type ModifySeatAssignmentEvent struct {
 	Request
-	Assign   []Principal
-	UnAssign []Principal
+	Assign   []vo.SubjectID
+	UnAssign []vo.SubjectID
 	Org      Organization
 	Service  Service
 }

--- a/domain/model/ModifySeatAssignmentEvent.go
+++ b/domain/model/ModifySeatAssignmentEvent.go
@@ -8,20 +8,3 @@ type ModifySeatAssignmentEvent struct {
 	Org      Organization
 	Service  Service
 }
-
-// IsValid performs some validation on the event to ensure internal consistency
-func (m ModifySeatAssignmentEvent) IsValid() bool {
-	for _, principal := range m.Assign {
-		if principal.OrgID != m.Org.ID {
-			return false
-		}
-	}
-
-	for _, principal := range m.UnAssign {
-		if principal.OrgID != m.Org.ID {
-			return false
-		}
-	}
-
-	return true
-}

--- a/domain/model/Principal.go
+++ b/domain/model/Principal.go
@@ -1,11 +1,11 @@
 package model
 
+import vo "authz/domain/valueobjects"
+
 // A Principal is an identity that may have some authority
 type Principal struct {
 	//IDs are permanent and unique identifying values.
-	ID string
-	//OrgIDs represent the organization a principal is a member of.
-	OrgID string
+	ID vo.SubjectID
 }
 
 // IsAnonymous returns true if this Principal has no identity information and returns false if this Principal represents a specific identity
@@ -14,8 +14,8 @@ func (p Principal) IsAnonymous() bool {
 }
 
 // NewPrincipal constructs a new principal with the given identifier.
-func NewPrincipal(id string, orgID string) Principal {
-	return Principal{ID: id, OrgID: orgID}
+func NewPrincipal(id vo.SubjectID) Principal {
+	return Principal{ID: id}
 }
 
 // NewAnonymousPrincipal constructs a new principal without an identity.

--- a/domain/model/Principal_test.go
+++ b/domain/model/Principal_test.go
@@ -13,7 +13,7 @@ func TestPrincipalIsAnonymousTrueForAnonymousPrincipal(t *testing.T) {
 }
 
 func TestPrincipalIsAnonymousFalseForSpecificPrincipal(t *testing.T) {
-	p := NewPrincipal("alice", "aspian")
+	p := NewPrincipal("alice")
 
 	assert.False(t, p.IsAnonymous(), "Should NOT have been anonymous.")
 }

--- a/domain/model/Request.go
+++ b/domain/model/Request.go
@@ -1,7 +1,9 @@
 package model
 
+import "authz/domain/valueobjects"
+
 // A Request represents the parameters common to all requests
 type Request struct {
 	//The principal sending the request
-	Requestor Principal
+	Requestor valueobjects.SubjectID
 }

--- a/domain/services/AccessService.go
+++ b/domain/services/AccessService.go
@@ -19,7 +19,7 @@ func NewAccessService(accessRepository contracts.AccessRepository) AccessService
 
 // Check processes a CheckEvent and returns true or false if successful, otherwise error
 func (a AccessService) Check(req model.CheckEvent) (vo.AccessDecision, error) {
-	if req.Requestor.IsAnonymous() {
+	if !req.Requestor.HasIdentity() {
 		return false, model.ErrNotAuthenticated
 	}
 
@@ -32,5 +32,5 @@ func (a AccessService) Check(req model.CheckEvent) (vo.AccessDecision, error) {
 		return false, model.ErrNotAuthorized
 	}
 
-	return a.accessRepository.CheckAccess(req.Subject, req.Operation, req.Resource)
+	return a.accessRepository.CheckAccess(req.SubjectID, req.Operation, req.Resource)
 }

--- a/domain/services/AccessService.go
+++ b/domain/services/AccessService.go
@@ -23,7 +23,7 @@ func (a AccessService) Check(req model.CheckEvent) (vo.AccessDecision, error) {
 		return false, model.ErrNotAuthenticated
 	}
 
-	accessResult, err := a.accessRepository.CheckAccess(req.Requestor, "call", model.Resource{Type: "endpoint", ID: "checkaccess"})
+	accessResult, err := true, error(nil) //a.accessRepository.CheckAccess(req.Requestor, "call", model.Resource{Type: "endpoint", ID: "checkaccess"}) //TODO: implement actual meta-authz
 	if err != nil {
 		return false, err
 	}

--- a/domain/services/AccessService_test.go
+++ b/domain/services/AccessService_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestCheckErrorsWhenCallerNotAuthorized(t *testing.T) {
+	t.SkipNow()
 	access := NewAccessService(mockAuthzRepository())
 	_, err := access.Check(objFromRequest(
 		"other system",

--- a/domain/services/AccessService_test.go
+++ b/domain/services/AccessService_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"authz/domain/contracts"
 	"authz/domain/model"
+	vo "authz/domain/valueobjects"
 	"authz/infrastructure/repository/mock"
 	"testing"
 )
@@ -61,18 +62,18 @@ func TestCheckReturnsFalseWhenStoreReturnsFalse(t *testing.T) {
 func objFromRequest(requestorID string, subjectID string, operation string, resourceType string, resourceID string) model.CheckEvent {
 	return model.CheckEvent{
 		Request: model.Request{
-			Requestor: model.Principal{ID: requestorID},
+			Requestor: vo.SubjectID(requestorID),
 		},
-		Subject:   model.Principal{ID: subjectID},
+		SubjectID: vo.SubjectID(subjectID),
 		Operation: operation,
 		Resource:  model.Resource{Type: resourceType, ID: resourceID},
 	}
 }
 
 func mockAuthzRepository() contracts.AccessRepository {
-	return &mock.StubAccessRepository{Data: map[string]bool{
+	return &mock.StubAccessRepository{Data: map[vo.SubjectID]bool{
 		"system": true,
 		"okay":   true,
 		"bad":    false,
-	}, LicensedSeats: map[string]map[string]bool{}}
+	}, LicensedSeats: map[vo.SubjectID]map[string]bool{}}
 }

--- a/domain/services/SeatLicenseService.go
+++ b/domain/services/SeatLicenseService.go
@@ -47,7 +47,7 @@ func (l *SeatLicenseService) ensureRequestorIsAuthorizedToManageLicenses(request
 		return model.ErrNotAuthenticated
 	}
 
-	authz, err := l.authz.CheckAccess(requestor, "manage_license", org.AsResource()) //Maybe on a per-service basis?
+	authz, err := true, error(nil) //l.authz.CheckAccess(requestor, "manage_license", org.AsResource()) //Maybe on a per-service basis? //TODO: implement meta-authz
 	if err != nil {
 		return err
 	}

--- a/domain/services/SeatLicenseService.go
+++ b/domain/services/SeatLicenseService.go
@@ -3,6 +3,7 @@ package services
 import (
 	"authz/domain/contracts"
 	"authz/domain/model"
+	vo "authz/domain/valueobjects"
 )
 
 // SeatLicenseService performs operations related to per-seat licensing
@@ -38,8 +39,8 @@ func NewSeatLicenseService(seats contracts.SeatLicenseRepository, authz contract
 	return &SeatLicenseService{seats: seats, authz: authz}
 }
 
-func (l *SeatLicenseService) ensureRequestorIsAuthorizedToManageLicenses(requestor model.Principal) error {
-	if requestor.IsAnonymous() {
+func (l *SeatLicenseService) ensureRequestorIsAuthorizedToManageLicenses(requestor vo.SubjectID) error {
+	if !requestor.HasIdentity() {
 		return model.ErrNotAuthenticated
 	}
 

--- a/domain/services/SeatLicenseService_test.go
+++ b/domain/services/SeatLicenseService_test.go
@@ -39,21 +39,6 @@ func TestLicensingModifySeatsErrorsWhenNotAuthorized(t *testing.T) {
 	assert.ErrorIs(t, err, model.ErrNotAuthorized)
 }
 
-func TestLicensingUnAssignSeatsErrorsWhenSubjectAndRequestOrgsMismatched(t *testing.T) {
-	req := modifyLicRequestFromVars("okay",
-		"aspian",
-		"bspian",
-		[]string{"okay"},
-		[]string{})
-
-	store := mockAuthzRepository()
-	lic := NewSeatLicenseService(store.(contracts.SeatLicenseRepository), store)
-
-	err := lic.ModifySeats(req)
-
-	assert.ErrorIs(t, err, model.ErrInvalidRequest)
-}
-
 func TestLicensingAssignUnassignRoundTrip(t *testing.T) {
 	addReq := modifyLicRequestFromVars("okay",
 		"aspian",

--- a/domain/services/SeatLicenseService_test.go
+++ b/domain/services/SeatLicenseService_test.go
@@ -24,6 +24,7 @@ func TestLicensingModifySeatsErrorsWhenNotAuthenticated(t *testing.T) {
 }
 
 func TestLicensingModifySeatsErrorsWhenNotAuthorized(t *testing.T) {
+	t.SkipNow()
 	req := modifyLicRequestFromVars("bad",
 		"aspian",
 		"aspian",

--- a/domain/services/SeatLicenseService_test.go
+++ b/domain/services/SeatLicenseService_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"authz/domain/contracts"
 	"authz/domain/model"
+	vo "authz/domain/valueobjects"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,6 @@ import (
 
 func TestLicensingModifySeatsErrorsWhenNotAuthenticated(t *testing.T) {
 	req := modifyLicRequestFromVars("",
-		"aspian",
 		"aspian",
 		[]string{"okay"},
 		[]string{})
@@ -27,7 +27,6 @@ func TestLicensingModifySeatsErrorsWhenNotAuthorized(t *testing.T) {
 	t.SkipNow()
 	req := modifyLicRequestFromVars("bad",
 		"aspian",
-		"aspian",
 		[]string{"okay"},
 		[]string{})
 
@@ -41,7 +40,6 @@ func TestLicensingModifySeatsErrorsWhenNotAuthorized(t *testing.T) {
 
 func TestLicensingAssignUnassignRoundTrip(t *testing.T) {
 	addReq := modifyLicRequestFromVars("okay",
-		"aspian",
 		"aspian",
 		[]string{"okay"},
 		[]string{})
@@ -62,7 +60,6 @@ func TestLicensingAssignUnassignRoundTrip(t *testing.T) {
 
 	remReq := modifyLicRequestFromVars("okay",
 		"aspian",
-		"aspian",
 		[]string{},
 		[]string{"okay"})
 
@@ -74,23 +71,23 @@ func TestLicensingAssignUnassignRoundTrip(t *testing.T) {
 	assert.False(t, bool(authz), "Should not have been authorized without license.")
 }
 
-func modifyLicRequestFromVars(requestorID string, requestorOrg string, subjectOrg string, assign []string, unassign []string) model.ModifySeatAssignmentEvent {
+func modifyLicRequestFromVars(requestorID string, subjectOrg string, assign []string, unassign []string) model.ModifySeatAssignmentEvent {
 	evt := model.ModifySeatAssignmentEvent{
 		Request: model.Request{
-			Requestor: model.NewPrincipal(requestorID, requestorOrg),
+			Requestor: vo.SubjectID(requestorID),
 		},
 		Org:     model.Organization{ID: subjectOrg},
 		Service: model.Service{ID: "smarts"},
 	}
 
-	evt.Assign = make([]model.Principal, len(assign))
+	evt.Assign = make([]vo.SubjectID, len(assign))
 	for i, id := range assign {
-		evt.Assign[i] = model.NewPrincipal(id, requestorOrg)
+		evt.Assign[i] = vo.SubjectID(id)
 	}
 
-	evt.UnAssign = make([]model.Principal, len(unassign))
+	evt.UnAssign = make([]vo.SubjectID, len(unassign))
 	for i, id := range unassign {
-		evt.UnAssign[i] = model.NewPrincipal(id, requestorOrg)
+		evt.UnAssign[i] = vo.SubjectID(id)
 	}
 
 	return evt

--- a/domain/valueobjects/SubjectID.go
+++ b/domain/valueobjects/SubjectID.go
@@ -1,0 +1,9 @@
+package valueobjects
+
+// SubjectID represents a reference to a subject on the platform
+type SubjectID string
+
+// HasIdentity is a helper method that indicates whether this SubjectID represents an identity
+func (p SubjectID) HasIdentity() bool {
+	return p != ""
+}

--- a/infrastructure/repository/authzed/SpiceDbAccessRepository.go
+++ b/infrastructure/repository/authzed/SpiceDbAccessRepository.go
@@ -28,8 +28,8 @@ type authzedClient struct {
 var authzedConn *authzedClient
 
 // CheckAccess -
-func (s *SpiceDbAccessRepository) CheckAccess(principal model.Principal, operation string, resource model.Resource) (vo.AccessDecision, error) {
-	s2, o2 := createSubjectObjectTuple("user", principal.ID, resource.Type, resource.ID)
+func (s *SpiceDbAccessRepository) CheckAccess(subjectID vo.SubjectID, operation string, resource model.Resource) (vo.AccessDecision, error) {
+	s2, o2 := createSubjectObjectTuple("user", string(subjectID), resource.Type, resource.ID)
 
 	//TODO remove me, just for checking it is used (will return an err)
 	_, err := authzedConn.client.ReadSchema(authzedConn.ctx, &v1.ReadSchemaRequest{})

--- a/infrastructure/repository/fga/OpenFgaAccessRepository.go
+++ b/infrastructure/repository/fga/OpenFgaAccessRepository.go
@@ -23,13 +23,13 @@ type OpenFgaClient struct {
 var openfgaConn *OpenFgaClient
 
 // CheckAccess -
-func (o OpenFgaAccessRepository) CheckAccess(principal model.Principal, operation string, resource model.Resource) (vo.AccessDecision, error) {
+func (o OpenFgaAccessRepository) CheckAccess(subjectID vo.SubjectID, operation string, resource model.Resource) (vo.AccessDecision, error) {
 	trace := false
 
 	body := openfga.CheckRequest{TupleKey: openfga.TupleKey{
 		Object:   openfga.PtrString(resource.ID),
 		Relation: openfga.PtrString(operation),
-		User:     openfga.PtrString(principal.ID),
+		User:     openfga.PtrString(string(subjectID)),
 	}, ContextualTuples: nil, AuthorizationModelId: openfga.PtrString("foo"), Trace: &trace}
 
 	result, _, err := openfgaConn.client.OpenFgaApi.Check(context.Background()).Body(body).Execute()

--- a/infrastructure/repository/mock/StubAccessRepository.go
+++ b/infrastructure/repository/mock/StubAccessRepository.go
@@ -31,7 +31,7 @@ func (s *StubAccessRepository) CheckAccess(principal model.Principal, operation 
 }
 
 // AssignSeat assigns the given principal a seat for the given service
-func (s *StubAccessRepository) AssignSeat(principal model.Principal, svc model.Service) error {
+func (s *StubAccessRepository) AssignSeat(principal model.Principal, orgID string, svc model.Service) error {
 	if lics, ok := s.LicensedSeats[principal.ID]; ok {
 		lics[svc.ID] = true
 	} else {
@@ -41,7 +41,7 @@ func (s *StubAccessRepository) AssignSeat(principal model.Principal, svc model.S
 }
 
 // UnAssignSeat removes the seat assignment for the given principal for the given service
-func (s *StubAccessRepository) UnAssignSeat(principal model.Principal, svc model.Service) error {
+func (s *StubAccessRepository) UnAssignSeat(principal model.Principal, orgID string, svc model.Service) error {
 	if lics, ok := s.LicensedSeats[principal.ID]; ok {
 		lics[svc.ID] = false
 	}

--- a/infrastructure/repository/mock/StubAccessRepository.go
+++ b/infrastructure/repository/mock/StubAccessRepository.go
@@ -9,8 +9,8 @@ import (
 // StubAccessRepository represents an in-memory authorization system with a fixed state
 type StubAccessRepository struct {
 	//The internal authorization state. The keys are subject IDs, and the values are the results. The results are the same per subject regardless of operation and resource.
-	Data          map[string]bool
-	LicensedSeats map[string]map[string]bool
+	Data          map[vo.SubjectID]bool
+	LicensedSeats map[vo.SubjectID]map[string]bool
 }
 
 // NewConnection Stub impl
@@ -19,10 +19,10 @@ func (s *StubAccessRepository) NewConnection(_ string, _ string, _ bool) {
 }
 
 // CheckAccess returns true if the subject has been specified to have access, otherwise false.
-func (s *StubAccessRepository) CheckAccess(principal model.Principal, operation string, resource model.Resource) (vo.AccessDecision, error) {
-	if authz, ok := s.Data[principal.ID]; ok {
+func (s *StubAccessRepository) CheckAccess(subjectID vo.SubjectID, operation string, resource model.Resource) (vo.AccessDecision, error) {
+	if authz, ok := s.Data[subjectID]; ok {
 		if authz && operation == "use" {
-			return vo.AccessDecision(s.LicensedSeats[principal.ID][resource.ID]), nil //Authorized, so return license status
+			return vo.AccessDecision(s.LicensedSeats[subjectID][resource.ID]), nil //Authorized, so return license status
 		}
 		return vo.AccessDecision(authz), nil //No licensing required, passthrough authz status
 	}
@@ -31,18 +31,18 @@ func (s *StubAccessRepository) CheckAccess(principal model.Principal, operation 
 }
 
 // AssignSeat assigns the given principal a seat for the given service
-func (s *StubAccessRepository) AssignSeat(principal model.Principal, orgID string, svc model.Service) error {
-	if lics, ok := s.LicensedSeats[principal.ID]; ok {
+func (s *StubAccessRepository) AssignSeat(subjectID vo.SubjectID, _ string, svc model.Service) error {
+	if lics, ok := s.LicensedSeats[subjectID]; ok {
 		lics[svc.ID] = true
 	} else {
-		s.LicensedSeats[principal.ID] = map[string]bool{svc.ID: true}
+		s.LicensedSeats[subjectID] = map[string]bool{svc.ID: true}
 	}
 	return nil
 }
 
 // UnAssignSeat removes the seat assignment for the given principal for the given service
-func (s *StubAccessRepository) UnAssignSeat(principal model.Principal, orgID string, svc model.Service) error {
-	if lics, ok := s.LicensedSeats[principal.ID]; ok {
+func (s *StubAccessRepository) UnAssignSeat(subjectID vo.SubjectID, _ string, svc model.Service) error {
+	if lics, ok := s.LicensedSeats[subjectID]; ok {
 		lics[svc.ID] = false
 	}
 

--- a/infrastructure/repository/mock/StubPrincipalRepository.go
+++ b/infrastructure/repository/mock/StubPrincipalRepository.go
@@ -2,15 +2,16 @@ package mock
 
 import (
 	"authz/domain/model"
+	vo "authz/domain/valueobjects"
 )
 
 // StubPrincipalRepository represents an in-memory store of principal data
 type StubPrincipalRepository struct {
-	Principals map[string]model.Principal
+	Principals map[vo.SubjectID]model.Principal
 }
 
 // GetByID retrieves a principal for the given ID. If no ID is provided (ex: empty string), it returns an anonymous principal. If any error occurs, it's returned.
-func (s *StubPrincipalRepository) GetByID(id string) (model.Principal, error) {
+func (s *StubPrincipalRepository) GetByID(id vo.SubjectID) (model.Principal, error) {
 	if id == "" {
 		return model.NewAnonymousPrincipal(), nil
 	}
@@ -24,7 +25,7 @@ func (s *StubPrincipalRepository) GetByID(id string) (model.Principal, error) {
 }
 
 // GetByIDs is a bulk version of GetByID to allow the underlying implementation to optimize access to sets of principals and should otherwise have the same behavior.
-func (s *StubPrincipalRepository) GetByIDs(ids []string) ([]model.Principal, error) {
+func (s *StubPrincipalRepository) GetByIDs(ids []vo.SubjectID) ([]model.Principal, error) {
 	principals := make([]model.Principal, len(ids))
 
 	for i, id := range ids {
@@ -37,7 +38,7 @@ func (s *StubPrincipalRepository) GetByIDs(ids []string) ([]model.Principal, err
 	return principals, nil
 }
 
-func (s *StubPrincipalRepository) createAndAddMissingPrincipal(id string) (model.Principal, error) {
+func (s *StubPrincipalRepository) createAndAddMissingPrincipal(id vo.SubjectID) (model.Principal, error) {
 	p := model.Principal{ID: id}
 
 	s.Principals[id] = p

--- a/infrastructure/repository/mock/StubPrincipalRepository.go
+++ b/infrastructure/repository/mock/StubPrincipalRepository.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"authz/domain/model"
-	"errors"
 )
 
 // StubPrincipalRepository represents an in-memory store of principal data
@@ -21,7 +20,7 @@ func (s *StubPrincipalRepository) GetByID(id string) (model.Principal, error) {
 		return principal, nil
 	}
 
-	return principal, errors.New("not found") //Nil instead of error?
+	return s.createAndAddMissingPrincipal(id)
 }
 
 // GetByIDs is a bulk version of GetByID to allow the underlying implementation to optimize access to sets of principals and should otherwise have the same behavior.
@@ -36,4 +35,12 @@ func (s *StubPrincipalRepository) GetByIDs(ids []string) ([]model.Principal, err
 	}
 
 	return principals, nil
+}
+
+func (s *StubPrincipalRepository) createAndAddMissingPrincipal(id string) (model.Principal, error) {
+	p := model.Principal{ID: id}
+
+	s.Principals[id] = p
+
+	return p, nil
 }


### PR DESCRIPTION
This one may have gotten a bit out of hand, but it's three commits that are aiming for three high-level goals:
- Making the placeholder authz logic inactive so it's out of the way but easy to implement in the future and the PrincipalRepository open to just-in-time test data (all Gets succeed)
- Removing the (incorrect) business logic around org membership and, since it's no longer needed, removing org information from the Principal domain model. The Org domain model wasn't removed yet but potentially could be.
- Trimmed down current use of the Principal domain model to a SubjectID value object since working with principals by reference is an important part of our domain. This also removes all (even simulated) interaction with external systems from the Check path.