### PR TITLE
renaming and cleaning check permission for spicedb impl

### DIFF
--- a/infrastructure/repository/authzed/SpiceDbAccessRepository.go
+++ b/infrastructure/repository/authzed/SpiceDbAccessRepository.go
@@ -5,8 +5,9 @@ import (
 	"authz/domain/model"
 	vo "authz/domain/valueobjects"
 	"context"
-	"github.com/golang/glog"
 	"log"
+
+	"github.com/golang/glog"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/authzed-go/v1"
@@ -15,6 +16,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// SubjectType user
 const SubjectType = "user"
 
 // SpiceDbAccessRepository -

--- a/infrastructure/repository/authzed/SpiceDbAccessRepository.go
+++ b/infrastructure/repository/authzed/SpiceDbAccessRepository.go
@@ -5,9 +5,8 @@ import (
 	"authz/domain/model"
 	vo "authz/domain/valueobjects"
 	"context"
-	"log"
-
 	"github.com/golang/glog"
+	"log"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/authzed-go/v1"
@@ -15,6 +14,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+const SubjectType = "user"
 
 // SpiceDbAccessRepository -
 type SpiceDbAccessRepository struct{}
@@ -27,32 +28,27 @@ type authzedClient struct {
 
 var authzedConn *authzedClient
 
-// CheckAccess -
+// CheckAccess - verify permission with subject type "user"
 func (s *SpiceDbAccessRepository) CheckAccess(subjectID vo.SubjectID, operation string, resource model.Resource) (vo.AccessDecision, error) {
-	s2, o2 := createSubjectObjectTuple("user", string(subjectID), resource.Type, resource.ID)
+	subject, object := createSubjectObjectTuple(SubjectType, string(subjectID), resource.Type, resource.ID)
 
-	//TODO remove me, just for checking it is used (will return an err)
-	_, err := authzedConn.client.ReadSchema(authzedConn.ctx, &v1.ReadSchemaRequest{})
-	if err != nil {
-		glog.Infof("Could not reach spiceDB! Error: %v", err)
-	}
-
-	//TODO: Implement.
-	r, err := authzedConn.client.CheckPermission(authzedConn.ctx, &v1.CheckPermissionRequest{
-		Resource:   o2,
+	result, err := authzedConn.client.CheckPermission(authzedConn.ctx, &v1.CheckPermissionRequest{
+		Resource:   object,
 		Permission: operation,
-		Subject:    s2,
+		Subject:    subject,
 	})
 
 	if err != nil {
+		glog.Errorf("Failed to check permission :%v", err.Error())
 		return false, err
 	}
 
-	if r.Permissionship != v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION {
-		return false, nil
+	if result.Permissionship == v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION {
+		return true, nil
 	}
 
-	return true, nil
+	//DENIED BY DEFAULT
+	return false, nil
 }
 
 // NewConnection creates a new connection to an underlying SpiceDB store and saves it to the package variable conn
@@ -87,9 +83,9 @@ func createSubjectObjectTuple(subjectType string, subjectValue string, objectTyp
 		ObjectId:   subjectValue,
 	}}
 
-	t1 := &v1.ObjectReference{
+	object := &v1.ObjectReference{
 		ObjectType: objectType,
 		ObjectId:   objectValue,
 	}
-	return subject, t1
+	return subject, object
 }


### PR DESCRIPTION

Renaming variables and cleanup
Add logging to help with debugging the errors

# How to verify

- Run Spicedb using the kind commands and schema
- Portward spicedb deployment to localhost:50051

``` ./authz serve --endpoint=localhost:50051 --token=<key-goes-here> --store=spicedb ```

Verify check permission end-point
 ``` curl -X POST localhost:8081/v1alpha/check -H "Content-Type: application/json" -H "Authorization: token" -d '{"subject": "u1", "operation": "access", "resourcetype": "license", "resourceid": "o1/smarts"}' ```