### PR TITLE
Intial implementation for seat assign/unassign in spicedb store

### DIFF
--- a/api/http/Server_test.go
+++ b/api/http/Server_test.go
@@ -118,7 +118,7 @@ func createTestServer() *grpc.Server {
 
 	return &grpc.Server{
 		AccessAppService:  application.NewAccessAppService(&accessRepo, principalRepo),
-		LicenseAppService: application.NewLicenseAppService(accessRepo, licenseRepo, principalRepo),
+		LicenseAppService: application.NewLicenseAppService(&accessRepo, &licenseRepo, principalRepo),
 	}
 }
 

--- a/application/LicenseAppService.go
+++ b/application/LicenseAppService.go
@@ -10,8 +10,8 @@ import (
 
 // LicenseAppService the handler for seat related endpoints.
 type LicenseAppService struct {
-	accessRepo    contracts.AccessRepository
-	seatRepo      contracts.SeatLicenseRepository
+	accessRepo    *contracts.AccessRepository
+	seatRepo      *contracts.SeatLicenseRepository
 	principalRepo contracts.PrincipalRepository
 	ctx           context.Context
 }
@@ -26,7 +26,7 @@ type ModifySeatAssignmentRequest struct {
 }
 
 // NewLicenseAppService ctor.
-func NewLicenseAppService(accessRepo contracts.AccessRepository, seatRepo contracts.SeatLicenseRepository, principalRepo contracts.PrincipalRepository) *LicenseAppService {
+func NewLicenseAppService(accessRepo *contracts.AccessRepository, seatRepo *contracts.SeatLicenseRepository, principalRepo contracts.PrincipalRepository) *LicenseAppService {
 	return &LicenseAppService{
 		accessRepo:    accessRepo,
 		seatRepo:      seatRepo,
@@ -54,7 +54,7 @@ func (s *LicenseAppService) ModifySeats(req ModifySeatAssignmentRequest) error {
 		evt.UnAssign[i] = vo.SubjectID(id)
 	}
 
-	seatService := services.NewSeatLicenseService(s.seatRepo, s.accessRepo)
+	seatService := services.NewSeatLicenseService(*s.seatRepo, *s.accessRepo)
 
 	return seatService.ModifySeats(evt)
 }

--- a/bootstrap/SeatLicenseRepositoryBuilder.go
+++ b/bootstrap/SeatLicenseRepositoryBuilder.go
@@ -1,6 +1,9 @@
 package bootstrap
 
-import "authz/domain/contracts"
+import (
+	"authz/domain/contracts"
+	"authz/infrastructure/repository/authzed"
+)
 
 // SeatLicenseRepositoryBuilder constructs SeatLicenseRepositories based on the provided configuration
 type SeatLicenseRepositoryBuilder struct {
@@ -28,6 +31,8 @@ func (b *SeatLicenseRepositoryBuilder) WithStore(store string) *SeatLicenseRepos
 // Build constructs the repository
 func (b *SeatLicenseRepositoryBuilder) Build() contracts.SeatLicenseRepository {
 	switch b.store {
+	case "spicedb":
+		return &authzed.SpiceDbAccessRepository{}
 	case "stub":
 		return b.stub
 	default:

--- a/bootstrap/app.go
+++ b/bootstrap/app.go
@@ -34,7 +34,7 @@ func Run(endpoint string, token string, store string) {
 		},
 	}
 	aas := application.NewAccessAppService(&ar, pr)
-	sas := application.NewLicenseAppService(ar, sr, pr)
+	sas := application.NewLicenseAppService(&ar, &sr, pr)
 
 	wait := sync.WaitGroup{}
 
@@ -51,6 +51,7 @@ func Run(endpoint string, token string, store string) {
 
 	webSrv := getHTTPServer(&srvCfg)
 	webSrv.SetCheckRef(srv)
+	webSrv.SetSeatRef(srv)
 
 	go func() {
 		err := webSrv.


### PR DESCRIPTION
# Description
Basic implementation for Assign/Unassing seat license for spicedb store
Fixed issues with seatlicense repo intialization

TODO: Can be follow-up PRs or tackled in separate sub-task/jira
- precondition/filters
- permission check
- add test for assigned/unassign

# How to verify

* Create Spicedb using kind commands in make file
* Port forward spicedb deployment 
* Run Authz service
`./authz serve --endpoint=localhost:50051 --token=spice-db-preshared-api-key-goes-here --store=spicedb
`

## Check assign end-point
```
curl --location 'localhost:8081/v1alpha/orgs/aspian/licenses/smarts' \
--header 'Authorization: Bearer token' \
--header 'Content-Type: application/json' \
--data '{
  "assign": [
    "u7"
  ]
}'
```
## Unassign
```
curl --location 'localhost:8081/v1alpha/orgs/aspian/licenses/smarts' \
--header 'Authorization: Bearer token' \
--header 'Content-Type: application/json' \
--data '{
  "unassign": [
    "u7"
  ]
}'
```



