### PR TITLE
Enable blocking to true for spiceDB grpc dial

### DIFF
--- a/bootstrap/app.go
+++ b/bootstrap/app.go
@@ -20,11 +20,11 @@ func Run(endpoint string, token string, store string) {
 	ar.NewConnection(
 		endpoint,
 		token,
-		false)
+		true)
 
 	srvCfg := api.ServerConfig{ //TODO: Discuss config.
 		GrpcPort:  "50051",
-		HTTPPort:  "8080",
+		HTTPPort:  "8081",
 		HTTPSPort: "8443",
 		TLSConfig: api.TLSConfig{
 			CertPath: "/etc/tls/tls.crt",


### PR DESCRIPTION
The spiceDB connection downstream is broken, and trying this fix to gather more information.

Co-Authored-by: William Scalf