### PR TITLE
Enable CA verification

### DIFF
--- a/infrastructure/repository/authzed/SpiceDbAccessRepository.go
+++ b/infrastructure/repository/authzed/SpiceDbAccessRepository.go
@@ -330,9 +330,9 @@ func (s *SpiceDbAccessRepository) NewConnection(spiceDbEndpoint string, token st
 
 	if !useTLS {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	} else { // Use TLS - but for now SKIP CA verification
-		skipCA, _ := grpcutil.WithSystemCerts(grpcutil.VerifyCA)
-		opts = append(opts, skipCA)
+	} else {
+		tlsConfig, _ := grpcutil.WithSystemCerts(grpcutil.VerifyCA)
+		opts = append(opts, tlsConfig)
 	}
 
 	client, err := authzed.NewClient(

--- a/infrastructure/repository/authzed/SpiceDbAccessRepository.go
+++ b/infrastructure/repository/authzed/SpiceDbAccessRepository.go
@@ -331,7 +331,7 @@ func (s *SpiceDbAccessRepository) NewConnection(spiceDbEndpoint string, token st
 	if !useTLS {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else { // Use TLS - but for now SKIP CA verification
-		skipCA, _ := grpcutil.WithSystemCerts(grpcutil.SkipVerifyCA)
+		skipCA, _ := grpcutil.WithSystemCerts(grpcutil.VerifyCA)
 		opts = append(opts, skipCA)
 	}
 


### PR DESCRIPTION
This PR naively enables CA verification in the grpc client to SpiceDB.
According to the [documentation](https://pkg.go.dev/github.com/authzed/grpcutil#WithSystemCerts), grpcutil.WithSystemCerts() already handles finding the default root CA certs for the system, which theoretically should include the generated root CA cert for OpenShift, so it seems likely this just works, and I think it'd be good to try it.

If it _doesn't_ just work, we should probably backlog it, but if it does, hey, easy win.