### PR TITLE
initial DoD Template based on decided DoD Doc

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+### PR Template:
+
+* [ ] Is the agreed upon acceptance criteria fullfilled?
+
+* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)
+
+* [ ] Do your changes have passing automated tests and sufficient observability?
+
+* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
+  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
+  * [ ] An SOP (Standard Operating Procedure) was created
+
+* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)
+
+* [ ] Are the agreed upon coding/architectural practices applied?
+
+* [ ] Are security needs fullfilled? (e.g. no internal URL)
+
+* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)
+
+* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?  
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ### PR Template:
 
-* [ ] Is the agreed upon acceptance criteria fullfilled?
+* [ ] Are the agreed upon acceptance criteria fulfilled?
 
 * [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)
 


### PR DESCRIPTION
Done using [this](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) guide. 

Guess it has to be merged to see if it works for the next PR.