### PR TITLE
Update development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ Authz calls out to SpiceDB on grpc/50051 by default if the command line, below, 
 2. Ensure there is a SpiceDB token string in `.secrets/spice-db-local`. It will be loaded into a secret and used by SpiceDB.
 3. `make kind-create-schema-configmap` to make the default schema and test relationships available to SpiceDB from a ConfigMap.
 4. `make kind-spicedb-deploy` to deploy SpiceDB in the kind cluster.
-5. `kubectl port-forward $(kubectl get pods -oname -l app.kubernetes.io/name=spicedb --field-selector=status.phase==Running) 50051:50051` to port forward from localhost 50051 to the SpiceDB pod on kind running on 50051. (This command does not exit, so continue on another terminal.)
+5. `kubectl port-forward $(kubectl get pods -oname -l app.kubernetes.io/name=spicedb --field-selector=status.phase==Running) 60000:50051` to port forward from localhost 60000 to the SpiceDB pod on kind running on 50051. (Port forward from 60000 to keep 50051 free for authz grpc port. This command does not exit, so continue on another terminal.)
 6. `make binary` to build the authz service locally.
-7. `./bin/authz --endpoint=localhost:50051 --token=$(cat .secrets/spice-db-local) --store=spicedb` (This command does not exit, so continue on another terminal.)
+7. `./bin/authz --endpoint=localhost:60000 --token=$(cat .secrets/spice-db-local) --store=spicedb` (This command does not exit, so continue on another terminal.)
 8. `./scripts/test.sh localhost:8081` to verify the setup with a smoke test.


### PR DESCRIPTION
Fix local setup to avoid conflict of authz and spicedb grpc ports.

### PR Template:

## Describe your changes

- Local development docs change to port forward to kind spicedb on a port that isn't 50051, to avoid a conflict with authz's grpc server on the same port on localhost.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [x] Are the agreed upon acceptance criteria fulfilled?

* [x] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [x] Do your changes have passing automated tests and sufficient observability?

* [x] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [x] Are the agreed upon coding/architectural practices applied?

* [x] Are security needs fullfilled? (e.g. no internal URL)

* [x] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [x] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

