### PR TITLE
bump authzed-go and fix deprecated function call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module authz
 go 1.19
 
 require (
-	github.com/authzed/authzed-go v0.7.0
+	github.com/authzed/authzed-go v0.8.0
 	github.com/authzed/grpcutil v0.0.0-20230109193425-40ce0530e048
 	github.com/golang/glog v1.1.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEV
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/authzed/authzed-go v0.7.0 h1:etnzHUAIyxGiEaFYJPYkHTHzxCYWEGzZQMgVLe4xRME=
-github.com/authzed/authzed-go v0.7.0/go.mod h1:bmjzzIQ34M0+z8NO9SLjf4oA0A9Ka9gUWVzeSbD0E7c=
+github.com/authzed/authzed-go v0.8.0 h1:gb4X+7RxVqXSCFReAnKmSda68TBIqRdc47W2spLqoEc=
+github.com/authzed/authzed-go v0.8.0/go.mod h1:h9Zar1MSSrVsqbcbE5/RO7gpg6Fx5QYW2C5QduSox5M=
 github.com/authzed/grpcutil v0.0.0-20230109193425-40ce0530e048 h1:pBStde+5xTAEFP5gGkOMbnDbpCHg1hAWBv7N0VEnDMY=
 github.com/authzed/grpcutil v0.0.0-20230109193425-40ce0530e048/go.mod h1:rqjY3zyK/YP7NID9+B2BdIRRkvnK+cdf9/qya/zaFZE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/infrastructure/repository/authzed/SpiceDbAccessRepository.go
+++ b/infrastructure/repository/authzed/SpiceDbAccessRepository.go
@@ -283,7 +283,7 @@ func (s *SpiceDbAccessRepository) GetAssigned(orgID string, serviceID string) ([
 			return nil, err
 		}
 
-		ids = append(ids, domain.SubjectID(next.SubjectObjectId))
+		ids = append(ids, domain.SubjectID(next.Subject.SubjectObjectId))
 	}
 	return ids, nil
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

- bump authzed-go to 0.8 and fix deprecated function call. 

## Ticket reference (if applicable)
Fixes #

## Checklist

* [x] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [x] Do your changes have passing automated tests and sufficient observability?

* [x] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [x] Are the agreed upon coding/architectural practices applied?

* [x] Are security needs fullfilled? (e.g. no internal URL)

* [x] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [x] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

