### PR TITLE
Allows multiple issuers/providers to be supported in AuthnInterceptor

### DIFF
--- a/api/grpc/Server.go
+++ b/api/grpc/Server.go
@@ -155,7 +155,7 @@ func (s *Server) Serve(wait *sync.WaitGroup) error {
 			s.ServerConfig.GrpcPort)
 	}
 
-	authConfigs := []api.AuthConfig{s.ServerConfig.AuthConfig}
+	authConfigs := []api.AuthConfig{s.ServerConfig.AuthConfig} // TODO: wire up with new file-based config functionality
 	authMiddleware, err := interceptor.NewAuthnInterceptor(authConfigs)
 	if err != nil {
 		glog.Fatalf("Error: Not able to reach discovery endpoint to initialize authentication middleware.")

--- a/api/grpc/Server.go
+++ b/api/grpc/Server.go
@@ -155,7 +155,8 @@ func (s *Server) Serve(wait *sync.WaitGroup) error {
 			s.ServerConfig.GrpcPort)
 	}
 
-	authMiddleware, err := interceptor.NewAuthnInterceptor(s.ServerConfig.AuthConfig)
+	authConfigs := []api.AuthConfig{s.ServerConfig.AuthConfig}
+	authMiddleware, err := interceptor.NewAuthnInterceptor(authConfigs)
 	if err != nil {
 		glog.Fatalf("Error: Not able to reach discovery endpoint to initialize authentication middleware.")
 	}


### PR DESCRIPTION
### PR Template:

## Describe your changes

- We want to be able to support multiple issuers/OIDC providers in the AuthnInterceptor, to support various scenarios.
- An incoming bearer token will be validated against each configured provider until either a) one of them validates and introspects the token, or b) all providers are tried and none can/will validate the token.

## Ticket reference (if applicable)
Fixes #CIAM-5932

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [x] Do your changes have passing automated tests and sufficient observability?

* [x] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [x] Are the agreed upon coding/architectural practices applied?

* [x] Are security needs fullfilled? (e.g. no internal URL)

* [x] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [x] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

