### PR TITLE
Add more validations for authConfig.

### DIFF
--- a/api/grpc/interceptor/AuthnInterceptor.go
+++ b/api/grpc/interceptor/AuthnInterceptor.go
@@ -46,8 +46,8 @@ type providerJSON struct {
 
 // NewAuthnInterceptor creates a new AuthnInterceptor
 func NewAuthnInterceptor(configs []api.AuthConfig) (*AuthnInterceptor, error) {
-	if configs == nil {
-		return nil, fmt.Errorf("configs should not be nil")
+	if err := validateAuthConfigs(configs); err != nil {
+		return nil, err
 	}
 
 	var providers []*authnProvider
@@ -61,6 +61,28 @@ func NewAuthnInterceptor(configs []api.AuthConfig) (*AuthnInterceptor, error) {
 	}
 
 	return &AuthnInterceptor{providers}, nil
+}
+
+func validateAuthConfigs(configs []api.AuthConfig) (err error) {
+	if configs == nil {
+		return fmt.Errorf("configs should not be nil")
+	}
+
+	checked := make(map[api.AuthConfig]bool)
+
+	for _, config := range configs {
+		if config == (api.AuthConfig{}) {
+			return fmt.Errorf("authnconfig should not be zero value")
+		}
+
+		if checked[config] {
+			return fmt.Errorf("authnconfigs should not have duplicates")
+		}
+
+		checked[config] = true
+	}
+
+	return
 }
 
 // configureAuthnProvider constructor


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Added validation for authConfigs (`validateAuthConfigs` called at the top of `NewAuthnInterceptor`).
- Did not refactor to use a function like `configureAuthnProvider(config api.AuthConfig) (*authnProvider, error)` in tests as intended, which would have created the whole provider from the configs, because this function involves calling out to the discovery endpoints via the key cache (which would be a pain to mock).

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

