### PR TITLE
Fix for the panic when no authconfig is given

### DIFF
--- a/api/grpc/Server.go
+++ b/api/grpc/Server.go
@@ -163,8 +163,10 @@ func (s *Server) Serve(wait *sync.WaitGroup) error {
 		}
 		s.srv = grpc.NewServer(grpc.Creds(creds), authMiddleware.Unary())
 	} else {
+		// local dev: no authconfig given, so we enable a passthrough middleware to get the requestor from authorization header.
+		authMiddleware := interceptor.NewPassthroughAuthnInterceptor()
 		glog.Warning("Client authorization disabled. Do not use in production use cases!")
-		s.srv = grpc.NewServer(grpc.Creds(creds))
+		s.srv = grpc.NewServer(grpc.Creds(creds), authMiddleware.Unary())
 	}
 
 	core.RegisterCheckPermissionServer(s.srv, s)

--- a/api/grpc/interceptor/PassthroughAuthnInterceptor.go
+++ b/api/grpc/interceptor/PassthroughAuthnInterceptor.go
@@ -1,0 +1,23 @@
+package interceptor
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+// PassthroughAuthnInterceptor - passthrough AuthN Middleware for usage in local dev use cases where authN does not matter.
+type PassthroughAuthnInterceptor struct{}
+
+// NewPassthroughAuthnInterceptor creates a new PassthroughAuthnInterceptor
+func NewPassthroughAuthnInterceptor() *PassthroughAuthnInterceptor {
+	return &PassthroughAuthnInterceptor{}
+}
+
+// Unary impl of the Unary passthrough interceptor, returning a static value in the context..
+func (authnInterceptor *PassthroughAuthnInterceptor) Unary() grpc.ServerOption {
+	return grpc.UnaryInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+
+		return handler(context.WithValue(ctx, RequestorContextKey, "static-subject"), req)
+	})
+}

--- a/config.yaml
+++ b/config.yaml
@@ -10,15 +10,15 @@
 #     endpoint: <spicedb endpoint>
 #     tokenFile: <path to file containing spicedb preshared key>
 
-#grpcPort: 50052 # GRPC port of the AuthZ service
+#grpcPort: 50051 # GRPC port of the AuthZ service
 httpPort: 8081 # HTTP port of the Authz Service. Defaults to 8080
 #httpsPort: 8443 # HTTPS port of the AuthZ service
 logRequests: true # Request logging midddleware on/off - true/false. Defaults to false
 auth:
-        -   enabled: false # Recommended for local dev, when there is no AuthN server integration, no checks for the tokens.
-            audience: cloud-services # Used when auth in enabled, audience of the token
-            discoveryEndpoint: http://localhost:8180/idp/.well-known/openid-configuration # Used when auth in enabled, discovery endpoint of the token issuer
-            requiredScope: openid # used when auth in enabled, the required scopes to validate for in the given token
+    -   enabled: false # Recommended for local dev, when there is no AuthN server integration, no checks for the tokens.
+        audience: cloud-services # Used when auth in enabled, audience of the token
+        discoveryEndpoint: http://localhost:8180/idp/.well-known/openid-configuration # Used when auth in enabled, discovery endpoint of the token issuer
+        requiredScope: openid # used when auth in enabled, the required scopes to validate for in the given token
 cors: # (Refer to https://github.com/rs/cors for settings)
     #allowCredentials: false
     allowedOrigins:
@@ -43,8 +43,8 @@ cors: # (Refer to https://github.com/rs/cors for settings)
     debug: true #Default: false
     #maxAge: 300
 store:
-    endpoint: localhost:50051 # End point where the spiceDB store runs, GRPC endpoint
-    #kind: stub # stub - local stub implementation within the code, spicedb - external store
+    endpoint: localhost:60000 # End point where the spiceDB store runs, GRPC endpoint
+    kind: stub # stub - local stub implementation within the code, spicedb - external store
     tokenFile: .secrets/spice-db-local # Needed for store=spicedb, path to the pre-shared token
     useTLS: false # TLS enabled/disabled between authz service and store (spiceDB) Defaults to true
 #tls:


### PR DESCRIPTION
Introduces PassthroughInterceptor when all AuthConfigs are set to enabled:false

### PR Template:

## Describe your changes

- introduce PassthroughInterceptor with static requestorID
- 

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

