### PR TITLE
Fix for triggering the import when an org + members are in the schema…

### DIFF
--- a/application/LicenseAppService_test.go
+++ b/application/LicenseAppService_test.go
@@ -50,7 +50,7 @@ func TestOrgEnablement(t *testing.T) {
 	assert.Equal(t, 20, len(assignable))
 }
 
-func TestImportDoesGetSkippedIfAtLeastOneLicenseAndAtLeastOneMemberAlreadyExistsInAnOrg(t *testing.T) {
+func TestUserImportIsSkippedIfAtLeastOneLicenseAlreadyExistsForAnOrg(t *testing.T) {
 	//given
 	spy := &OrgRepositoryWithDetectableImportState{}
 	service, _ := createService(nil, spy)

--- a/bootstrap/app_test.go
+++ b/bootstrap/app_test.go
@@ -123,7 +123,7 @@ func TestUnassignLicenseReturnsSuccess(t *testing.T) {
 	assertJSONResponse(t, resp, 200, `{}`)
 }
 
-func TestEntitleOrgSucceedsAndStartsImportWithNewOrgAndNewOrServiceLicense(t *testing.T) {
+func TestEntitleOrgSucceedsWithNewOrgAndNewOrServiceLicense(t *testing.T) {
 	setupService()
 	defer teardownService()
 	_, err := http.DefaultClient.Do(post("/v1alpha/orgs/o3/entitlements/foobar", "system",
@@ -160,9 +160,10 @@ func TestEntitleOrgSucceedstWithExistingOrgAndNewLicenses(t *testing.T) {
 	assertJSONResponse(t, resp2, 200, `{"seatsAvailable":20, "seatsTotal": 20}`)
 }
 
-func TestEntitleOrgSucceedsButDoesSkipImportWithExistingOrgAndSameLicense(t *testing.T) {
+func TestEntitleOrgTwiceFailsWithBadRequest(t *testing.T) {
 	setupService()
 	defer teardownService()
+
 	_, err := http.DefaultClient.Do(post("/v1alpha/orgs/o3/entitlements/foobar", "system",
 		`{
 			"maxSeats": 25
@@ -181,7 +182,7 @@ func TestEntitleOrgSucceedsButDoesSkipImportWithExistingOrgAndSameLicense(t *tes
 
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-
+	//to make sure the license didn't get messed up we also assert that the seatcount is the expected one
 	resp4, err := http.DefaultClient.Do(get("/v1alpha/orgs/o3/licenses/foobar", "system"))
 	assert.NoError(t, err)
 	assertJSONResponse(t, resp4, 200, `{"seatsAvailable":25, "seatsTotal": 25}`)
@@ -628,7 +629,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	temporarySecretDirectory, err = os.MkdirTemp(".", ".secrets")
+	temporarySecretDirectory, err = os.MkdirTemp(os.TempDir(), ".secrets")
 	if err != nil {
 		glog.Error("Error setting up secret directory: ", err)
 		os.Exit(1)

--- a/domain/contracts/SeatLicenseRepository.go
+++ b/domain/contracts/SeatLicenseRepository.go
@@ -16,6 +16,6 @@ type SeatLicenseRepository interface {
 	GetAssigned(orgID string, serviceID string) ([]domain.SubjectID, error)
 	// ApplyLicense stores the given license associated with its service and organization
 	ApplyLicense(license *domain.License) error
-	// IsLicensed returns true if a given Org has at least one license applied.
-	IsLicensed(orgID string) (bool, error)
+	// IsImported returns true if a given Org has at least one license applied or exists and has at least one member in the schema.
+	IsImported(orgID string) (bool, error)
 }


### PR DESCRIPTION
…, but no license is there.

* as it is the case for our test relations. o2 has members, but no license. The import was triggered but failed to import. License was still applied, which is expected.

* Fixes the situation when an org was already imported, but all license data was deleted later on. The tuples for org + members would still be there.

### PR Template:

## Describe your changes

- Fix for triggering the import when an org + members are in the schema, but no license is there.
- as it is the case for our test relations. o2 has members, but no license. The import was triggered but failed to import. License was still applied, which is expected.
- Fixes the situation when an org was already imported, but all license data was deleted later on. The tuples for org + members would still be there. I guess this might be a quite common scenario when an org has a license for some time, then the license is removed sometime later. Also, our test relations.yaml has org o2 with members but without a license. All in all, even if we don't delete the actual license data later on in this situation, we'd be safe and not call the external userservice a lot whenever a new license is applied for an existing org.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

