### PR TITLE
Ciam 5756 seat admin meta auth z

### DIFF
--- a/api/grpc/interceptor/AuthnInterceptor.go
+++ b/api/grpc/interceptor/AuthnInterceptor.go
@@ -36,7 +36,10 @@ type ContextKey string
 
 const (
 	// RequestorContextKey Key for the Requestor value
-	RequestorContextKey           ContextKey = ContextKey("Requestor")
+	RequestorContextKey ContextKey = ContextKey("Requestor")
+	// RequestorOrgContextKey Key for Requestor org
+	RequestorOrgContextKey ContextKey = ContextKey("RequestorOrgContextKey")
+	// IsRequestorOrgAdminContextKey Key for asserting whether requestor is admin of the above org
 	IsRequestorOrgAdminContextKey ContextKey = ContextKey("IsOrgAdmin")
 )
 
@@ -147,7 +150,7 @@ func (authnInterceptor *AuthnInterceptor) Unary() grpc.ServerOption {
 			return nil, status.Error(codes.Unauthenticated, "Anonymous access is not allowed.")
 		}
 
-		result, err := authnInterceptor.validateTokenAndExtractSubject(token)
+		result, err := authnInterceptor.validateTokenAndExtractData(token)
 
 		if err != nil {
 			glog.Errorf("Error processing token: %s", err)
@@ -156,14 +159,14 @@ func (authnInterceptor *AuthnInterceptor) Unary() grpc.ServerOption {
 
 		// Context with multiple values - derive a context from context
 		ctx = context.WithValue(ctx, RequestorContextKey, result.SubjectID)
-		isOrgAdmin := isRequestorOrgAdmin(token)
-		ctx = context.WithValue(ctx, IsRequestorOrgAdminContextKey, isOrgAdmin)
+		ctx = context.WithValue(ctx, RequestorOrgContextKey, result.Org)
+		ctx = context.WithValue(ctx, IsRequestorOrgAdminContextKey, result.IsOrgAdmin)
 
 		return handler(ctx, req)
 	})
 }
 
-func (authnInterceptor *AuthnInterceptor) validateTokenAndExtractSubject(token string) (result tokenIntrospectionResult, err error) {
+func (authnInterceptor *AuthnInterceptor) validateTokenAndExtractData(token string) (result tokenIntrospectionResult, err error) {
 	jwtoken, err := jwt.ParseString(token, jwt.WithVerify(false), jwt.WithValidate(false)) //Parse without any validation to peek issuer
 
 	if err != nil {
@@ -174,7 +177,7 @@ func (authnInterceptor *AuthnInterceptor) validateTokenAndExtractSubject(token s
 
 	for _, provider := range authnInterceptor.providers {
 		if issuer == provider.issuer {
-			result, err = validateTokenAndExtractSubject(provider, token)
+			result, err = validateTokenAndExtractData(provider, token)
 
 			return
 		}
@@ -185,7 +188,7 @@ func (authnInterceptor *AuthnInterceptor) validateTokenAndExtractSubject(token s
 	return
 }
 
-func validateTokenAndExtractSubject(p *authnProvider, token string) (result tokenIntrospectionResult, err error) {
+func validateTokenAndExtractData(p *authnProvider, token string) (result tokenIntrospectionResult, err error) {
 	//Parse with signature verification and token validation. Second parse is necessary because WithKeySet cannot be passed to jwt.Validate
 	jwtoken, err := jwt.ParseString(token, jwt.WithKeySet(p.verificationKeys), jwt.WithIssuer(p.issuer), jwt.WithAudience(p.audience))
 
@@ -199,9 +202,12 @@ func validateTokenAndExtractSubject(p *authnProvider, token string) (result toke
 	}
 
 	result.SubjectID = jwtoken.Subject()
-	if result.SubjectID == "" {
+	result.Org, result.IsOrgAdmin = requestorOrg(jwtoken)
+
+	if result.SubjectID == "" || result.Org == "" {
 		err = domain.ErrNotAuthenticated
 	}
+
 	return
 }
 
@@ -226,7 +232,9 @@ func ensureRequiredScope(requiredScope string, token jwt.Token) error {
 }
 
 type tokenIntrospectionResult struct {
-	SubjectID string
+	SubjectID  string
+	Org        string
+	IsOrgAdmin bool
 }
 
 func getBearerTokenFromContext(ctx context.Context) string {
@@ -248,12 +256,14 @@ func getBearerTokenFromContext(ctx context.Context) string {
 	return ""
 }
 
-func isRequestorOrgAdmin(token string) (isOrgAdmin bool) {
-	tk, _ := jwt.ParseString(token)
-	if claims := tk.PrivateClaims(); claims != nil {
+func requestorOrg(token jwt.Token) (orgID string, isOrgAdmin bool) {
+	if claims := token.PrivateClaims(); claims != nil {
+		if claims["org_id"] != nil {
+			orgID = claims["org_id"].(string)
+		}
 		if claims["is_org_admin"] != nil {
-			return claims["is_org_admin"].(bool)
+			isOrgAdmin = claims["is_org_admin"].(bool)
 		}
 	}
-	return false
+	return orgID, isOrgAdmin
 }

--- a/bootstrap/app_test.go
+++ b/bootstrap/app_test.go
@@ -580,11 +580,11 @@ func assertJSONResponse(t *testing.T, resp *http.Response, statusCode int, templ
 }
 
 func get(relativeURI string, subject string, orgID string, isOrgAdmin bool) *http.Request {
-	return createRequest(http.MethodGet, relativeURI, testenv.SubjectIDToToken(subject, orgID, isOrgAdmin), "")
+	return createRequest(http.MethodGet, relativeURI, testenv.CreateToken(subject, orgID, isOrgAdmin), "")
 }
 
 func post(relativeURI string, subject string, orgID string, isOrgAdmin bool, body string) *http.Request {
-	return createRequest(http.MethodPost, relativeURI, testenv.SubjectIDToToken(subject, orgID, isOrgAdmin), body)
+	return createRequest(http.MethodPost, relativeURI, testenv.CreateToken(subject, orgID, isOrgAdmin), body)
 }
 
 func createRequest(method string, relativeURI string, authToken string, body string) *http.Request {

--- a/bootstrap/app_test.go
+++ b/bootstrap/app_test.go
@@ -110,7 +110,6 @@ func TestAssignSeatReturnsFailureWhenOrgIsUnauthorized(t *testing.T) {
 func TestAssignSeatReturnsFailureWhenNotAuthorizedOrgAdmin(t *testing.T) {
 	setupService(nil)
 	defer teardownService()
-	// OrgID in request path and in the token are different
 	resp, err := http.DefaultClient.Do(post("/v1alpha/orgs/o1/licenses/smarts", "system", "o1", false, `{
 			"assign": [
 			  "u7"

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ auth:
 
 authz: #
     licenseImportWhitelist: # List of authorized/allowed subject IDs that can Entitle/Import Orgs
-    #    - subjectID1`
+    #    - subjectID1
     #    - SubjectID2
 
 cors: # (Refer to https://github.com/rs/cors for settings)

--- a/testenv/FakeIdp.go
+++ b/testenv/FakeIdp.go
@@ -89,7 +89,7 @@ func HostFakeIdp() {
 }
 
 // SubjectIDToToken creates a new jwt token for a given SubjectID
-func SubjectIDToToken(subject string, orgID string, isOrgAdmin bool) string {
+func CreateToken(subject string, orgID string, isOrgAdmin bool) string {
 	if subject == "" {
 		return ""
 	}

--- a/testenv/FakeIdp.go
+++ b/testenv/FakeIdp.go
@@ -88,7 +88,7 @@ func HostFakeIdp() {
 	}
 }
 
-// SubjectIDToToken creates a new jwt token for a given SubjectID
+// CreateToken creates a new jwt token for a given SubjectID, orgID and isOrgAdmin values
 func CreateToken(subject string, orgID string, isOrgAdmin bool) string {
 	if subject == "" {
 		return ""

--- a/testenv/FakeIdp.go
+++ b/testenv/FakeIdp.go
@@ -89,7 +89,7 @@ func HostFakeIdp() {
 }
 
 // SubjectIDToToken creates a new jwt token for a given SubjectID
-func SubjectIDToToken(subject string) string {
+func SubjectIDToToken(subject string, orgID string, isOrgAdmin bool) string {
 	if subject == "" {
 		return ""
 	}
@@ -100,6 +100,8 @@ func SubjectIDToToken(subject string) string {
 		Audience([]string{testAudience}).
 		Subject(subject).
 		Claim("scope", testRequiredScope).
+		Claim("org_id", orgID).
+		Claim("is_org_admin", isOrgAdmin).
 		Build()
 
 	if err != nil {


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Extracting orgID and isOrgAdmin from auth token in addition to subjectID and setting in context.
- Add logic to seat admin grpc Server methods to return unauthorized when requestor is not an org admin for the org they are intending to assign seats for. 

### Note

- As is, this change will break our smoke test, since the authenticated user running the smoke test must be an org admin for the "o1" org in the environment (i.e. stage/prod) we're running the smoke test against. This is because the smoke test calls seat admin endpoints.

## Ticket reference (if applicable)
Fixes #CIAM-5756.

## Checklist

* [x] Are the agreed upon acceptance criteria fulfilled?

* [x] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [x] Do your changes have passing automated tests and sufficient observability?

* [x] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [x] Are the agreed upon coding/architectural practices applied?

* [x] Are security needs fullfilled? (e.g. no internal URL)

* [x] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [x] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

