### PR TITLE
add test to hotfix from yesterday

### DIFF
--- a/bootstrap/app_test.go
+++ b/bootstrap/app_test.go
@@ -510,6 +510,23 @@ func TestGrantedLicenseAffectsCountsAndDetails(t *testing.T) {
 	assertJSONResponse(t, resp, 200, `{"users":"<<PRESENCE>>"}`)
 }
 
+func TestOrgWithoutUsersReturnsEmptyGetSeatsResponse(t *testing.T) {
+
+	var expectedSubjects []domain.Subject
+
+	expectedOrg := "oNoUsers"
+	usSrv := testenv.HostFakeUserServiceAPI(t, expectedSubjects, expectedOrg, map[int]int{}, CertDirectory)
+	defer usSrv.Server.Close()
+
+	setupService(usSrv)
+	defer teardownService()
+
+	resp, err := http.DefaultClient.Do(get("/v1alpha/orgs/oNoUsers/licenses/smarts/seats?filter=assignable&includeUsers=true", "system", "oNoUsers", true))
+	assert.NoError(t, err)
+	assertJSONResponse(t, resp, 200, `{"users":[]}`)
+
+}
+
 func TestOverAssigningLicensesFails(t *testing.T) {
 	setupService(nil)
 	defer teardownService()


### PR DESCRIPTION
* add test to hotfix from yesterday. To have a failing test first / try it out: comment out the 3 lines introduced by commit [91eb13c8](https://github.com/RedHatInsights/authz/commit/91eb13c8da8accf17f5d7db643e4fafc7412568c)

* Then running the test will fail as the result is not 200 anymore (actually 500)

* ..as the changed behaviour of the fake API now resembles the real one.

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes a hotfix introduced yesterday that did not have automated tests, for calling the frontend with an org without users, which led to calling the User API with empty userIds, which led to showing errors in the logs.

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

