### PR TITLE
Improve logging for assign / unassign operation.

### DIFF
--- a/infrastructure/repository/authzed/SpiceDbAccessRepository.go
+++ b/infrastructure/repository/authzed/SpiceDbAccessRepository.go
@@ -96,7 +96,7 @@ func (s *SpiceDbAccessRepository) ModifySeats(assignedSubjectIDs []domain.Subjec
 
 	// Step 2 Add license changes
 	relationshipUpdates, preconditions = addLicenseVersionSwap(relationshipUpdates, preconditions, license, assignedCount)
-
+	glog.Infof("Trying to assign %s and unassign %s seats on license %s for org %s with %d of %d seats currently in use.", assignedSubjectIDs, removedSubjectIDs, license.ServiceID, license.OrgID, license.InUse, license.MaxSeats)
 	// Step 3 submit transaction
 	result, err := s.client.WriteRelationships(s.ctx, &v1.WriteRelationshipsRequest{
 		Updates:               relationshipUpdates,
@@ -105,12 +105,12 @@ func (s *SpiceDbAccessRepository) ModifySeats(assignedSubjectIDs []domain.Subjec
 
 	// Step 4 examine any errors
 	if err != nil {
-		glog.Errorf("Failed to write modify seats :%v", err.Error())
+		glog.Errorf("Error assigning %s / unassigning %s seats on license %s for org %s with %d of %d seats currently in use.\nInternal error: %v", assignedSubjectIDs, removedSubjectIDs, license.ServiceID, license.OrgID, license.InUse, license.MaxSeats, err.Error())
 
 		return spiceDbErrorToDomainError(err)
 	}
 
-	glog.Infof("Assigned operation :%v", result)
+	glog.Infof("Successfully assigned %s / unassigned %s seats on license %s for org %s. Current seats used: %d of %d\n Internal response: %v", assignedSubjectIDs, removedSubjectIDs, license.ServiceID, license.OrgID, assignedCount, license.MaxSeats, result)
 
 	return nil
 }

--- a/infrastructure/repository/authzed/SpiceDbAccessRepository_test.go
+++ b/infrastructure/repository/authzed/SpiceDbAccessRepository_test.go
@@ -148,7 +148,7 @@ func TestUnassignBatch(t *testing.T) {
 
 	// given
 	subs := []domain.SubjectID{
-		"u1",
+		"u1", "u3",
 	}
 
 	oldLic, e1 := client.GetLicense("o1", "smarts")


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Added better logging to these operations. 
- Fixes the test `TestUnassignBatch` - I stumbled upon the fact that it did not batch-unassign at all, but just unassign one user. Was still green as we compare the count only.
- Could be improved way further by checking the error response and writing exact error reasons (e.g. "one user was inactive" or sth) - stayed away from this for another time (note for future improvers: extend`unwrapSpiceDbError` for these cases is imo the way to go here. ) 

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

