### PR TITLE
Stop tests retrying when non-200 http code returned

### DIFF
--- a/bootstrap/app_test.go
+++ b/bootstrap/app_test.go
@@ -717,9 +717,9 @@ func waitForSuccess(reqFactory func() *http.Request) error {
 
 	for {
 		req := reqFactory()
-		resp, err := http.DefaultClient.Do(req)
+		_, err := http.DefaultClient.Do(req)
 
-		if err == nil && resp.StatusCode == http.StatusOK {
+		if err == nil {
 			return nil
 		}
 


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Bug: a GET/POST returning a non-200 error code will not benefit from a retry, and the attempt slows/hangs tests that do not return 200s.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [x] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [x] Do your changes have passing automated tests and sufficient observability?

* [x] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [x] Are the agreed upon coding/architectural practices applied?

* [x] Are security needs fullfilled? (e.g. no internal URL)

* [x] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [x] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

