### PR TITLE
change set-output to new way of doing it

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -17,27 +17,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set short git commit SHA
-        id: vars
+        id: calc-short-sha
         run: |
           calculatedSha=$(git rev-parse --short=7 ${{ github.sha }})
-          echo "::set-output name=short_sha::$calculatedSha"
+          echo "SHORT_SHA=$calculatedSha" >> "$GITHUB_OUTPUT"
       - name: Confirm git commit SHA output
-        run: echo ${{ steps.vars.outputs.short_sha }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to Quay
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v4
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: | 
-            quay.io/ciam_authz/authz:latest,
-            quay.io/ciam_authz/authz:gh-${{ github.run_id }}-${{ github.run_attempt }}-${{ steps.vars.outputs.short_sha }}
+        run: echo ${{ steps.calc-short-sha.outputs.SHORT_SHA }}
+      #- name: Set up QEMU
+      #  uses: docker/setup-qemu-action@v2
+      #- name: Set up Docker Buildx
+      #  uses: docker/setup-buildx-action@v2
+      #- name: Login to Quay
+      #  uses: docker/login-action@v2
+      #  with:
+      #    registry: quay.io
+      #    username: ${{ secrets.QUAY_USERNAME }}
+      #    password: ${{ secrets.QUAY_TOKEN }}
+      #- name: Build and push
+      #  uses: docker/build-push-action@v4
+      #  with:
+      #    platforms: linux/amd64,linux/arm64
+      #    push: true
+      #    tags: |
+      #      quay.io/ciam_authz/authz:latest,
+      #      quay.io/ciam_authz/authz:gh-${{ github.run_id }}-${{ github.run_attempt }}-${{ steps.calc-short-sha.outputs.SHORT_SHA }}


### PR DESCRIPTION
* see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for details

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

