### PR TITLE
fix smoketest

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -75,7 +75,7 @@ testUserIsAssigned=1 #from this point, the test user is assigned and must be una
 
 msg="Getting number of seats available - should be less than the license allows. License allows (param): $maxSeats"
 echo "Test: $msg"
-previousAvailable=`( curl --silent --fail $baseUri/v1alpha/orgs/$orgId/licenses/smarts -H "Origin: http://smoketest.test" -H "Authorization:Bearer $token" || fail "Failed request: $msg") | jq ".seatsAvailable"`
+previousAvailable=`( curl --silent --fail $baseUri/v1alpha/orgs/$orgId/licenses/smarts -H "Origin: http://smoketest.test" -H "Authorization:Bearer $token" || fail "Failed request: $msg") | jq ".seatsAvailable|tonumber"`
 assert "$previousAvailable -lt $maxSeats" "$msg"
 
 echo "Waiting for quantization interval"
@@ -102,7 +102,7 @@ sleep 5
 
 msg='Getting license seat counts again - one more should be available'
 echo "Test: $msg"
-newAvailable=`( curl --silent --fail $baseUri/v1alpha/orgs/$orgId/licenses/smarts -H "Origin: http://smoketest.test" -H "Authorization:Bearer $token" || fail "Failed request: $msg" ) | jq ".seatsAvailable"`
+newAvailable=`( curl --silent --fail $baseUri/v1alpha/orgs/$orgId/licenses/smarts -H "Origin: http://smoketest.test" -H "Authorization:Bearer $token" || fail "Failed request: $msg" ) | jq ".seatsAvailable|tonumber"`
 assert "$previousAvailable -lt $newAvailable" "$msg"
 
 msg="Checking access for $userId again (should return false)"


### PR DESCRIPTION
uses jq 'isnumber' buitin

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

