### PR TITLE
Add CodeQL yaml for advanced mode

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -9,20 +9,29 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: "CodeQL analysis"
 
 on:
   push:
-    branches: [ "main","cql_test" ]
+    branches: [ "main"]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+    # do not run on md- or txt-only file changes
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+    # do not run on md- or txt-only file changes
   schedule:
-    - cron: '0/10 * * * *'
+    - cron: '0 0 * * *'
+  # ^ also scan every 24h at 12am because even if the code didn't change, the database may have changed.
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze code via CodeQL
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,0 +1,47 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main,cql_test]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+    # do not run on md- or txt-only file changes
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+
+    # do not run on md- or txt-only file changes
+  schedule:
+    - cron: '*/10 * * * *'
+
+jobs:
+  analyze:
+    name: Analyze code
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['go']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-severity=medium
+          # This will only alert for security findings with a severity of medium or higher.
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      # Perform CodeQL analysis.
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main","cql_test" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,31 +1,43 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
 name: "CodeQL"
 
 on:
   push:
-    branches: [main,cql_test]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
-    # do not run on md- or txt-only file changes
+    branches: [ "main" ]
   pull_request:
-    branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
-
-    # do not run on md- or txt-only file changes
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '0/10 * * * *'
 
 jobs:
   analyze:
-    name: Analyze code
-    runs-on: ubuntu-latest
+    name: Analyze
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false
       matrix:
-        language: ['go']
+        language: [ 'go' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
       - name: Checkout repository
@@ -36,12 +48,30 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
-          queries: +security-severity=medium
-          # This will only alert for security findings with a severity of medium or higher.
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+
+
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+      # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2
 
-      # Perform CodeQL analysis.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+      # - run: |
+      #     echo "Run, Build Application using script"
+      #     ./location_of_script_within_repo/buildscript.sh
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -29,6 +29,11 @@ on:
     - cron: '0 0 * * *'
   # ^ also scan every 24h at 12am because even if the code didn't change, the database may have changed.
 
+concurrency:
+  # Cancel in-progress runs on PR update
+  group: ci-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze code via CodeQL

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -29,11 +29,6 @@ on:
     - cron: '0 0 * * *'
   # ^ also scan every 24h at 12am because even if the code didn't change, the database may have changed.
 
-concurrency:
-  # Cancel in-progress runs on PR update
-  group: ci-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   analyze:
     name: Analyze code via CodeQL


### PR DESCRIPTION
### PR Template:

## Describe your changes

* gives us more control, and ability to re-run. See this response: https://github.com/github/codeql/discussions/13703#discussioncomment-6416403

* commented yaml is taken from their standard generated template when choosing advanced mode

* change included: do not run analysis on changes that only affect md / txt files to spare some github minutes (we have 2000 free minutes, a run takes around 4min)

* change included: also run codeQL every 24h because even when code does not change, the database definition to check against may change

when this is merged, we should check settings if severity level still applies, could not find a way to define that in yaml

## Ticket reference (if applicable)
Fixes CIAM-6398

## Checklist

* [x] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [x] Do your changes have passing automated tests and sufficient observability?

* [x] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [x] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [x] Are the agreed upon coding/architectural practices applied?

* [x] Are security needs fullfilled? (e.g. no internal URL)

* [x] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [x] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

