### PR TITLE
changing retry behaviour to how it was before PR #183

### DIFF
--- a/bootstrap/app_test.go
+++ b/bootstrap/app_test.go
@@ -643,7 +643,7 @@ func setupService(fakeUserService *testenv.FakeUserServiceAPI) {
 
 	go Run(temporaryConfigFile.Name())
 	err = waitForSuccess(func() *http.Request { //Repeat a check permission request until it succeeds or a timeout is reached
-		return post("/v1alpha/check", "system", "o3", true, `{"subject": "u2", "operation": "assigned", "resourcetype": "license_seats", "resourceid": "o1/smarts"}`)
+		return get("/v1alpha/healthcheck", "system", "o3", true)
 	})
 
 	if err != nil {
@@ -741,9 +741,9 @@ func waitForSuccess(reqFactory func() *http.Request) error {
 
 	for {
 		req := reqFactory()
-		_, err := http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req)
 
-		if err == nil {
+		if err == nil && resp.StatusCode == http.StatusOK {
 			return nil
 		}
 


### PR DESCRIPTION
to check if this removes the spurious 503s we see

### PR Template:

## Describe your changes

- Summary: The tests were previously waiting for a response from the proxy server (no communication error) which waited for the proxy to be active but offered no assurance that the grpc server was. When the proxy comes up before the grpc server, this opens up tests to fail with 503s.

- also changes the endpoint that is checked from "check" to the newly introduced "healthcheck" endpoint 

## Ticket reference (if applicable)
Fixes CIAM-6405

## Checklist

* [x] Are the agreed upon acceptance criteria fulfilled?

* [x] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [x] Do your changes have passing automated tests and sufficient observability?

* [x] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [x] Are the agreed upon coding/architectural practices applied?

* [x] Are security needs fullfilled? (e.g. no internal URL)

* [x] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [-] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

