### PR TITLE
temporarily disable audience validation in interceptor

### DIFF
--- a/api/grpc/interceptor/AuthnInterceptor.go
+++ b/api/grpc/interceptor/AuthnInterceptor.go
@@ -192,8 +192,9 @@ func (authnInterceptor *AuthnInterceptor) validateTokenAndExtractData(token stri
 }
 
 func validateTokenAndExtractData(p *authnProvider, token string) (result tokenIntrospectionResult, err error) {
+	// TODO: Re-introduce jwt.ParseString(token, jwt.WithKeySet(p.verificationKeys), jwt.WithIssuer(p.issuer), jwt.WithAudience(p.audience)) again when audience is in right shape. See CIAM-6318
 	//Parse with signature verification and token validation. Second parse is necessary because WithKeySet cannot be passed to jwt.Validate
-	jwtoken, err := jwt.ParseString(token, jwt.WithKeySet(p.verificationKeys), jwt.WithIssuer(p.issuer), jwt.WithAudience(p.audience))
+	jwtoken, err := jwt.ParseString(token, jwt.WithKeySet(p.verificationKeys), jwt.WithIssuer(p.issuer))
 
 	if err != nil {
 		return

--- a/api/grpc/interceptor/AuthnInterceptor_test.go
+++ b/api/grpc/interceptor/AuthnInterceptor_test.go
@@ -177,6 +177,8 @@ func TestInvalidTokenFromTheFuture(t *testing.T) {
 }
 
 func TestInvalidAudience(t *testing.T) {
+	// TODO: reintroduce when audience is in right shape to test it
+	t.SkipNow()
 	interceptor := AuthnInterceptor{[]*authnProvider{createAuthnProvider1()}}
 
 	builder := createDefaultTokenBuilder1().

--- a/bootstrap/serviceconfig/ServiceConfig.go
+++ b/bootstrap/serviceconfig/ServiceConfig.go
@@ -67,7 +67,7 @@ type CorsConfig struct {
 // AuthConfig holds the configuration for the client authz middleware
 type AuthConfig struct {
 	DiscoveryEndpoint string
-	Audience          string
+	Audience          string //currently not validated, see CIAM-6318
 	RequiredScope     string
 	Enabled           bool
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

- temporarily disable audience validation in interceptor until the environment has changed so this is actually useful.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [x] Are the agreed upon acceptance criteria fulfilled?

* [x] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [x] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [x] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

