### PR TITLE
Ciam 6318 reintroduce aud validation

### DIFF
--- a/api/grpc/interceptor/AuthnInterceptor.go
+++ b/api/grpc/interceptor/AuthnInterceptor.go
@@ -193,19 +193,19 @@ func (authnInterceptor *AuthnInterceptor) validateTokenAndExtractData(token stri
 
 func validateTokenAndExtractData(p *authnProvider, token string) (result tokenIntrospectionResult, err error) {
 	//Parse with signature verification and token validation. Second parse is necessary because WithKeySet cannot be passed to jwt.Validate
-	jwtoken, err := jwt.ParseString(token, jwt.WithKeySet(p.verificationKeys), jwt.WithIssuer(p.issuer), jwt.WithAudience(p.audience))
-	fmt.Errorf("TOKEN PARSING!")
+	jwtToken, err := jwt.ParseString(token, jwt.WithKeySet(p.verificationKeys), jwt.WithIssuer(p.issuer), jwt.WithAudience(p.audience))
+
 	if err != nil {
 		return
 	}
 
-	err = ensureRequiredScope(p.minimumScope, jwtoken)
+	err = ensureRequiredScope(p.minimumScope, jwtToken)
 	if err != nil {
 		return
 	}
 
-	result.SubjectID = jwtoken.Subject()
-	result.Org, result.IsOrgAdmin = requestorOrg(jwtoken)
+	result.SubjectID = jwtToken.Subject()
+	result.Org, result.IsOrgAdmin = requestorOrg(jwtToken)
 
 	if result.SubjectID == "" {
 		err = fmt.Errorf("%w: no sub claim found", domain.ErrNotAuthenticated)

--- a/api/grpc/interceptor/AuthnInterceptor.go
+++ b/api/grpc/interceptor/AuthnInterceptor.go
@@ -192,10 +192,9 @@ func (authnInterceptor *AuthnInterceptor) validateTokenAndExtractData(token stri
 }
 
 func validateTokenAndExtractData(p *authnProvider, token string) (result tokenIntrospectionResult, err error) {
-	// TODO: Re-introduce jwt.ParseString(token, jwt.WithKeySet(p.verificationKeys), jwt.WithIssuer(p.issuer), jwt.WithAudience(p.audience)) again when audience is in right shape. See CIAM-6318
 	//Parse with signature verification and token validation. Second parse is necessary because WithKeySet cannot be passed to jwt.Validate
-	jwtoken, err := jwt.ParseString(token, jwt.WithKeySet(p.verificationKeys), jwt.WithIssuer(p.issuer))
-
+	jwtoken, err := jwt.ParseString(token, jwt.WithKeySet(p.verificationKeys), jwt.WithIssuer(p.issuer), jwt.WithAudience(p.audience))
+	fmt.Errorf("TOKEN PARSING!")
 	if err != nil {
 		return
 	}

--- a/api/grpc/interceptor/AuthnInterceptor_test.go
+++ b/api/grpc/interceptor/AuthnInterceptor_test.go
@@ -177,8 +177,6 @@ func TestInvalidTokenFromTheFuture(t *testing.T) {
 }
 
 func TestInvalidAudience(t *testing.T) {
-	// TODO: reintroduce when audience is in right shape to test it
-	t.SkipNow()
 	interceptor := AuthnInterceptor{[]*authnProvider{createAuthnProvider1()}}
 
 	builder := createDefaultTokenBuilder1().

--- a/api/grpc/interceptor/AuthnInterceptor_test.go
+++ b/api/grpc/interceptor/AuthnInterceptor_test.go
@@ -186,6 +186,26 @@ func TestInvalidAudience(t *testing.T) {
 	assert.ErrorIs(t, err, jwt.ErrInvalidAudience())
 }
 
+func TestValidMultipleAudience(t *testing.T) {
+	interceptor := AuthnInterceptor{[]*authnProvider{createAuthnProvider1()}}
+
+	builder := createDefaultTokenBuilder1().
+		Audience([]string{"invalid-audience", validAudience1})
+	_, err := interceptor.validateTokenAndExtractData(createToken(builder, tokenSigningKey1))
+
+	assert.NoError(t, err)
+}
+
+func TestInvalidMultipleAudience(t *testing.T) {
+	interceptor := AuthnInterceptor{[]*authnProvider{createAuthnProvider1()}}
+
+	builder := createDefaultTokenBuilder1().
+		Audience([]string{"invalid-audience", "invalid2"})
+	_, err := interceptor.validateTokenAndExtractData(createToken(builder, tokenSigningKey1))
+
+	assert.ErrorIs(t, err, jwt.ErrInvalidAudience())
+}
+
 func TestInvalidIssuer(t *testing.T) {
 	interceptor := AuthnInterceptor{[]*authnProvider{createAuthnProvider1()}}
 

--- a/bootstrap/app_test.go
+++ b/bootstrap/app_test.go
@@ -729,6 +729,8 @@ func writeTestEnvToYaml(token string, userService *testenv.FakeUserServiceAPI) {
 	// Ensure the local discovery endpoint is used instead of any specified in the config
 	authKey["discoveryEndpoint"] = "http://localhost:8180/idp/.well-known/openid-configuration"
 
+	//set audience to its.us from fakeIdp to check for multiple aud parsing
+	authKey["audience"] = testenv.TestAudience2
 	// Override any config that is there for AuthZ - allow list with test specific data
 	yml["authz"] = make(map[string]interface{}, 0)
 	authzKey := yml["authz"].(map[string]interface{})

--- a/bootstrap/app_test.go
+++ b/bootstrap/app_test.go
@@ -729,8 +729,9 @@ func writeTestEnvToYaml(token string, userService *testenv.FakeUserServiceAPI) {
 	// Ensure the local discovery endpoint is used instead of any specified in the config
 	authKey["discoveryEndpoint"] = "http://localhost:8180/idp/.well-known/openid-configuration"
 
-	//set audience to its.us from fakeIdp to check for multiple aud parsing
+	//set allowed audience to 'its.us' from fakeIdp to check for multiple aud parsing
 	authKey["audience"] = testenv.TestAudience2
+
 	// Override any config that is there for AuthZ - allow list with test specific data
 	yml["authz"] = make(map[string]interface{}, 0)
 	authzKey := yml["authz"].(map[string]interface{})

--- a/bootstrap/serviceconfig/ServiceConfig.go
+++ b/bootstrap/serviceconfig/ServiceConfig.go
@@ -67,7 +67,7 @@ type CorsConfig struct {
 // AuthConfig holds the configuration for the client authz middleware
 type AuthConfig struct {
 	DiscoveryEndpoint string
-	Audience          string //currently not validated, see CIAM-6318
+	Audience          string
 	RequiredScope     string
 	Enabled           bool
 }

--- a/testenv/FakeIdp.go
+++ b/testenv/FakeIdp.go
@@ -20,7 +20,8 @@ const (
 	testKID    = "test-kid"
 	testIssuer = "http://localhost:8180/idp"
 
-	testAudience1     = "cloud-services"
+	testAudience1 = "cloud-services"
+	//TestAudience2 referenced in other tests
 	TestAudience2     = "its.us"
 	testRequiredScope = "openid"
 )

--- a/testenv/FakeIdp.go
+++ b/testenv/FakeIdp.go
@@ -20,7 +20,8 @@ const (
 	testKID    = "test-kid"
 	testIssuer = "http://localhost:8180/idp"
 
-	testAudience      = "cloud-services"
+	testAudience1     = "cloud-services"
+	TestAudience2     = "its.us"
 	testRequiredScope = "openid"
 )
 
@@ -93,7 +94,7 @@ func CreateToken(subject string, orgID string, isOrgAdmin bool) string {
 	data, err := jwt.NewBuilder().
 		Issuer(testIssuer).
 		IssuedAt(time.Now()).
-		Audience([]string{testAudience}).
+		Audience([]string{testAudience1, TestAudience2}).
 		Subject(subject).
 		Claim("scope", testRequiredScope).
 		Claim("org_id", orgID).


### PR DESCRIPTION
### PR Template:

## Describe your changes

- re-introduce audience checking
- internal config is already set up with the right aud claim to check, it's just not used as we had problems getting the right audience
- adds a few tests so we make sure multiple audiences are used and parsed correctly, even if we switch the lib sometime in the future

## Ticket reference (if applicable)
Fixes #

## Checklist

* [x] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [x] Do your changes have passing automated tests and sufficient observability?

* [x] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [x] Are the agreed upon coding/architectural practices applied?

* [x] Are security needs fullfilled? (e.g. no internal URL)

* [x] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [-] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

