### PR TITLE
Tighten up validation

### DIFF
--- a/application/AccessAppService.go
+++ b/application/AccessAppService.go
@@ -18,10 +18,10 @@ type AccessAppService struct {
 // CheckRequest is an actual request to check for permissions.
 type CheckRequest struct {
 	Requestor    string `validate:"required"`
-	Subject      string `validate:"required,spicedb-id"`
-	ResourceType string `validate:"required,spicedb-type"`
+	Subject      string `validate:"required,identifier"`
+	ResourceType string `validate:"required,in=license"`
 	ResourceID   string `validate:"required,spicedb-id"`
-	Operation    string `validate:"required,spicedb-permission"` //How to constrain further? List of values?
+	Operation    string `validate:"required,in=access"`
 }
 
 // NewAccessAppService returns a new instance of the permissionhandler.

--- a/application/LicenseAppService.go
+++ b/application/LicenseAppService.go
@@ -23,8 +23,8 @@ type LicenseAppService struct {
 // GetSeatAssignmentRequest represents a request to get the users assigned seats on a license
 type GetSeatAssignmentRequest struct {
 	Requestor    string `validate:"required"`
-	OrgID        string `validate:"required,spicedb-id"`
-	ServiceID    string `validate:"required,spicedb-id"`
+	OrgID        string `validate:"required,identifier"`
+	ServiceID    string `validate:"required,service"`
 	IncludeUsers bool
 	Assigned     bool
 }
@@ -32,29 +32,29 @@ type GetSeatAssignmentRequest struct {
 // ModifySeatAssignmentRequest represents a request to assign and/or unassign seat licenses
 type ModifySeatAssignmentRequest struct {
 	Requestor string   `validate:"required"`
-	OrgID     string   `validate:"required,spicedb-id"`
-	ServiceID string   `validate:"required,spicedb-id"`
-	Assign    []string `validate:"unique,dive,required,spicedb-id"`
-	Unassign  []string `validate:"unique,dive,required,spicedb-id"`
+	OrgID     string   `validate:"required,identifier"`
+	ServiceID string   `validate:"required,service"`
+	Assign    []string `validate:"unique,dive,required,identifier"`
+	Unassign  []string `validate:"unique,dive,required,identifier"`
 }
 
 // GetSeatAssignmentCountsRequest represents a request to get the seats limit and current allocation for a license
 type GetSeatAssignmentCountsRequest struct {
 	Requestor string `validate:"required"`
-	OrgID     string `validate:"required,spicedb-id"`
-	ServiceID string `validate:"required,spicedb-id"`
+	OrgID     string `validate:"required,identifier"`
+	ServiceID string `validate:"required,service"`
 }
 
 // OrgEntitledEvent represents an event where an organization has been entitled with a new license
 type OrgEntitledEvent struct {
-	OrgID     string `validate:"required,spicedb-id"`
-	ServiceID string `validate:"required,spicedb-id"`
+	OrgID     string `validate:"required,identifier"`
+	ServiceID string `validate:"required,service"`
 	MaxSeats  int    `validate:"required,gt=0"`
 }
 
 // ImportOrgEvent triggers new user import for an org
 type ImportOrgEvent struct {
-	OrgID string `validate:"required,spicedb-id"`
+	OrgID string `validate:"required,identifier"`
 }
 
 // ImportUsersResult contains counters for imported and not imported users.

--- a/application/Validation.go
+++ b/application/Validation.go
@@ -60,14 +60,29 @@ var spiceDbPermissionPattern = regexp.MustCompile(`^([a-z][a-z0-9_]{1,62}[a-z0-9
 var spiceDbTypePattern = regexp.MustCompile(`^([a-z][a-z0-9_]{1,61}[a-z0-9]/)?[a-z][a-z0-9_]{1,62}[a-z0-9]$`)
 
 func validateSpiceDbID(fl validator.FieldLevel) bool {
-	return spiceDbIDPattern.MatchString(fl.Field().String())
+	val := fl.Field().String()
+	if val == "" {
+		return true
+	}
+
+	return spiceDbIDPattern.MatchString(val)
 }
 
 func validateSpiceDbPermission(fl validator.FieldLevel) bool {
+	val := fl.Field().String()
+	if val == "" {
+		return true
+	}
+
 	return spiceDbPermissionPattern.MatchString(fl.Field().String())
 }
 
 func validateSpiceDbType(fl validator.FieldLevel) bool {
+	val := fl.Field().String()
+	if val == "" {
+		return true
+	}
+
 	return spiceDbTypePattern.MatchString(fl.Field().String())
 }
 
@@ -79,11 +94,16 @@ func validateIn(fl validator.FieldLevel) bool {
 	if !ok {
 		config = make(map[string]bool)
 
-		for _, val := range strings.Split(param, ",") {
+		for _, val := range strings.Split(param, "+") {
 			config[val] = true
 		}
 
 		inConfigCache[param] = config
+	}
+
+	val := fl.Field().String()
+	if val == "" {
+		return true
 	}
 
 	return config[fl.Field().String()]

--- a/application/Validation_test.go
+++ b/application/Validation_test.go
@@ -1,0 +1,48 @@
+package application
+
+import (
+	"authz/domain"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type validationTestCase struct {
+	ValueIn    string `validate:"in=valid+alsovalid"`
+	Identifier string `validate:"identifier"`
+	Service    string `validate:"service"`
+	expected   bool
+}
+
+func TestValidateValue(t *testing.T) {
+	tests := []validationTestCase{
+		{ValueIn: "valid", expected: true},
+		{ValueIn: "alsovalid", expected: true},
+		{ValueIn: "", expected: true},
+		{ValueIn: "invalid", expected: false},
+
+		{Identifier: "!!!", expected: false},
+		{Identifier: "12345678", expected: true},
+		{Identifier: "2c4111de-2a6a-11ee-b0d5-e7859b698bcf", expected: true},
+		{Identifier: "2c4111de-2a6a-11ee-b0d5-e7859b698bcf+", expected: false},
+
+		{Service: "smarts", expected: true},
+		{Service: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", expected: true},
+		{Service: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+", expected: false},
+		{Service: "!!!", expected: false},
+	}
+
+	for _, test := range tests {
+		err := ValidateStruct(test)
+		if test.expected {
+			assert.NoError(t, err, "Unexpected error. Case: %+v, err: %s", test, err)
+		} else {
+			var validationErr domain.ErrInvalidRequest
+			if assert.Error(t, err, "Expected validation error but got pass. Case: %+v", test) {
+				if assert.ErrorAs(t, err, &validationErr, "Expected validation error, got something else. Case: %+v, err: %s", test, err) {
+					assert.NotEqual(t, "", validationErr.Reason, "No reason given for validation error. Case: %+v, err: %s", test, err)
+				}
+			}
+		}
+	}
+}

--- a/bootstrap/app_test.go
+++ b/bootstrap/app_test.go
@@ -465,7 +465,7 @@ func TestGrantedLicenseAllowsUse(t *testing.T) {
 	setupService(nil)
 	defer teardownService()
 	//The user isn't licensed initially, use is denied
-	resp, err := http.DefaultClient.Do(post("/v1alpha/check", "checker", "o1", false, `{"subject": "u2", "operation": "assigned", "resourcetype": "license_seats", "resourceid": "o1/smarts"}`))
+	resp, err := http.DefaultClient.Do(post("/v1alpha/check", "checker", "o1", false, `{"subject": "u2", "operation": "access", "resourcetype": "license", "resourceid": "o1/smarts"}`))
 	assert.NoError(t, err)
 	assertJSONResponse(t, resp, 200, `{"result": %t, "description": ""}`, false)
 
@@ -480,7 +480,7 @@ func TestGrantedLicenseAllowsUse(t *testing.T) {
 	container.WaitForQuantizationInterval()
 
 	//Should be allowed now
-	resp, err = http.DefaultClient.Do(post("/v1alpha/check", "checker", "o1", false, `{"subject": "u2", "operation": "assigned", "resourcetype": "license_seats", "resourceid": "o1/smarts"}`))
+	resp, err = http.DefaultClient.Do(post("/v1alpha/check", "checker", "o1", false, `{"subject": "u2", "operation": "access", "resourcetype": "license", "resourceid": "o1/smarts"}`))
 	assert.NoError(t, err)
 	assertJSONResponse(t, resp, 200, `{"result": %t, "description": ""}`, true)
 }
@@ -608,7 +608,7 @@ func TestInvalidRequest(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assertJSONResponse(t, resp, 400, `{"code":3,"message":"Key: 'CheckRequest.Subject' Error:Field validation for 'Subject' failed on the 'spicedb-id' tag","details":[]}`)
+	assertJSONResponse(t, resp, 400, `{"code":3,"message":"Key: 'CheckRequest.Subject' Error:Field validation for 'Subject' failed on the 'identifier' tag","details":[]}`)
 }
 
 // Test helper methods start


### PR DESCRIPTION
Added 'in' validator for constrained lists
Added 'service' and 'identifier' aliases
Decorated event/message structs with stricter rules

### PR Template:

## Describe your changes

- Added 'in' validator for constrained lists
- Added 'service' and 'identifier' aliases
- Decorated event/message structs with stricter rules

## Ticket reference (if applicable)
Fixes #CIAM-6394

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

